### PR TITLE
SecureBootVariableLib: Set Payload point to NULL before initial use

### DIFF
--- a/SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.c
@@ -698,7 +698,7 @@ EnrollFromInput (
   IN VOID      *Data
   )
 {
-  VOID        *Payload;
+  VOID        *Payload = NULL;
   UINTN       PayloadSize;
   EFI_STATUS  Status;
 


### PR DESCRIPTION
Initialize Payload to NULL before use in line 765.
File: SecureBootVariableLib.c
765:   if (Payload != NULL) {
766:     FreePool (Payload);
767:     Payload = NULL;
768:   }
