### PR TITLE
SecurityPkg: Add missing debug print specifier

### DIFF
--- a/SecurityPkg/Library/MmTcg2PhysicalPresenceMinimumLib/MmTcg2PhysicalPresenceMinimumLibCommon.c
+++ b/SecurityPkg/Library/MmTcg2PhysicalPresenceMinimumLib/MmTcg2PhysicalPresenceMinimumLibCommon.c
@@ -181,7 +181,7 @@ EXIT:
   // Reset variable to no action on error
   //
   if (ReturnCode != TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "[TPM2] Submit PP Request failure! Reset variable to no action\n", Status));
+    DEBUG ((DEBUG_ERROR, "[TPM2] Submit PP Request failure! Reset variable to no action. Status = %r\n", Status));
     DataSize = sizeof (EFI_TCG2_PHYSICAL_PRESENCE);
     ZeroMem (&PpData, DataSize);
     Status = mTcg2PpSmmVariable->SmmSetVariable (

--- a/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/MmTcg2PhysicalPresenceLibCommon.c
+++ b/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/MmTcg2PhysicalPresenceLibCommon.c
@@ -191,7 +191,7 @@ EXIT:
   // Sync PPRQ/PPRM from PP Variable if PP submission fails
   //
   if (ReturnCode != TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS) {
-    DEBUG ((DEBUG_ERROR, "[TPM2] Submit PP Request failure! Sync PPRQ/PPRM with PP variable.\n", Status));
+    DEBUG ((DEBUG_ERROR, "[TPM2] Submit PP Request failure! Sync PPRQ/PPRM with PP variable. Status = %r\n", Status));
     DataSize = sizeof (EFI_TCG2_PHYSICAL_PRESENCE);
     ZeroMem (&PpData, DataSize);
     Status = mTcg2PpSmmVariable->SmmGetVariable (


### PR DESCRIPTION
## Description

The debug macros modified in this change were missing a print specifier
for a debug message argument given.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

- Verified build
- Verified DebugMacroCheck plugin results before and after
- 
## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
(partially cherry-picked from e495b1009a8ed118ab49f5020a77afc9b6d8f3f9)