### PR TITLE
Roll edk2-basetools back to 0.1.29

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,6 +14,6 @@
 
 edk2-pytool-library~=0.11.6 # MU_CHANGE
 edk2-pytool-extensions~=0.19.1 # MU_CHANGE
-edk2-basetools==0.1.39 # MU_CHANGE - update to 0.1.13 or later
+edk2-basetools==0.1.29 # MU_CHANGE - update to 0.1.13 or later
 antlr4-python3-runtime==4.11.1
 regex==2022.9.13


### PR DESCRIPTION
## Description

The 0.1.39 update breaks the build with the following error:

```
ImportError: cannot import name 'SubTypeGuidSectionClassObject'
  from 'CommonDataClass.FdfClass'
  (D:\a\1\s\MU_BASECORE\BaseTools\Source\Python\CommonDataClass\FdfClass.py)
```

This was missed in the original commit (49eefd0a07) PR gate because PR eval did not perform an actual build.

Roll this back for now until integration changes can be made to pull in the latest edk2-basetools update.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Restores previous functionality

## How This Was Tested

1. Verified CI build breaks with error in description with edk2-basetools 0.1.39
2. Verified CI build succeeds with edk2-basetools 0.1.29

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>