### PR TITLE
CISettings.py: Build PRs on .pytool and pip-requirements.txt changes

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -209,4 +209,20 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
 
     def FilterPackagesToTest(self, changedFilesList: list, potentialPackagesList: list) -> list:
         ''' Filter potential packages to test based on changed files. '''
-        return []
+        build_these_packages = []
+        possible_packages = potentialPackagesList.copy()
+
+        for f in changedFilesList:
+            # split each part of path for comparison later
+            nodes = f.split("/")
+
+            # python file change in .pytool folder causes building all
+            if f.endswith(".py") and ".pytool" in nodes:
+                build_these_packages = possible_packages
+                break
+
+            if "pip-requirements.txt" in nodes:
+                build_these_packages = possible_packages
+                break
+
+        return build_these_packages


### PR DESCRIPTION
## Description

Changes in these areas can have a substantial impact on build results
even though they are outside the package.

  - `.pytools`
  - `pip-requirements.txt`

This change updates `FilterPackagesToTest()` to build packages on
changes to these paths.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

- Tested changes in PR gate pipelines.
- Verified change to pip-requirements.txt triggered package builds

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>