### PR TITLE
Don't Set Access Attributes of Runtime MMIO Ranges

### DIFF
--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -155,7 +155,11 @@ SetRuntimeMemoryRangeAttributes (
     Status = gDS->SetMemorySpaceAttributes (
                     RuntimeMmioRanges->Range[Index].PhysicalBaseAddress,
                     (UINT64)RuntimeMmioRanges->Range[Index].Length,
-                    Descriptor.Attributes | EFI_MEMORY_RUNTIME
+                    // MU_CHANGE START: The memory space descriptor access attributes are not accurate. Don't pass
+                    //                  in access attributes so SetMemorySpaceAttributes() doesn't update them.
+                    // Descriptor.Attributes | EFI_MEMORY_RUNTIME
+                    EFI_MEMORY_RUNTIME
+                    // MU_CHANGE END
                     );
     ASSERT_EFI_ERROR (Status);
     if (EFI_ERROR (Status)) {


### PR DESCRIPTION
## Description

Passing in access attributes to SetMemorySpaceAttributes() will cause the existing attributes to be overwritten. The MMIO region should have the appropriate attributes applied during memory protection initialization and the attributes of the memory descriptor are inaccurate. Don't pass in any access attributes so the region stays secure.

## Breaking change?

No

## How This Was Tested

- Booting to the OS and running the paging audit app on Q35

## Integration Instructions

N/A
