### PR TITLE
Enable stale bot GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+name: Check for Stale Issues and Pull Requests
+
+on:
+  schedule:
+    # At 23:35 on every day-of-week from Sunday through Saturday
+    # https://crontab.guru/#35_23_*_*_0-6
+    - cron: '35 23 * * 0-6'
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@main


### PR DESCRIPTION
## Description

Enables stale bot to automatically closed old issues in this repo.
https://github.com/actions/stale

This action is largely based on a reusable workflow from Mu DevOps.

Current configuration:
  - Stale PR: After 60 days
  - Stale Issue: After 45 days
  - Days until PR and Issue close: 7 days
  - Exempt labels:
    - `impact:security`
    - `state:backlog`
    - `state:under-discussion`
  - Stale Issue label: `state:stale`
  - Stale PR label: `state:stale`
  - Comments are left when marked stale and when closed

These settings come directly from the default setting values in
the Mu DevOps reusable workflow.

Note: The `workflow_dispatch` trigger is added to allow the workflow to be manually
invoked if ever needed.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

- Verified workflow on mu_basecore fork.
   - Example run: https://github.com/makubacki/mu_basecore/actions/runs/3526648651
- Verified workflow in mu_basecore release/202208 branch

## Integration Instructions

N/A - Only affects the GitHub workflow in this repo

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>