### PR TITLE
Mark DMA memory allocations XP by default

### DIFF
--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
@@ -557,7 +557,7 @@ DmaAllocateAlignedBuffer (
   Status = gDS->SetMemorySpaceAttributes (
                   (PHYSICAL_ADDRESS)(UINTN)Allocation,
                   EFI_PAGES_TO_SIZE (Pages),
-                  MemType
+                  MemType | EFI_MEMORY_XP // MU_CHANGE: Allocate DMA memory XP by default
                   );
   if (EFI_ERROR (Status)) {
     goto FreeAlloc;

--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -159,7 +159,7 @@ SetRuntimeMemoryRangeAttributes (
                     //                  in access attributes so SetMemorySpaceAttributes() doesn't update them.
                     //                  EFI_MEMORY_RUNTIME is not a CPU arch attribute, so calling
                     //                  SetMemorySpaceAttributes() with only it set will not clear existing page table
-                    //                  attributes for this region, such EFI_MEMORY_XP
+                    //                  attributes for this region, such as EFI_MEMORY_XP
                     // Descriptor.Attributes | EFI_MEMORY_RUNTIME
                     EFI_MEMORY_RUNTIME
                     // MU_CHANGE END

--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -157,6 +157,9 @@ SetRuntimeMemoryRangeAttributes (
                     (UINT64)RuntimeMmioRanges->Range[Index].Length,
                     // MU_CHANGE START: The memory space descriptor access attributes are not accurate. Don't pass
                     //                  in access attributes so SetMemorySpaceAttributes() doesn't update them.
+                    //                  EFI_MEMORY_RUNTIME is not a CPU arch attribute, so calling
+                    //                  SetMemorySpaceAttributes() with only it set will not clear existing page table
+                    //                  attributes for this region, such EFI_MEMORY_XP
                     // Descriptor.Attributes | EFI_MEMORY_RUNTIME
                     EFI_MEMORY_RUNTIME
                     // MU_CHANGE END


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

When allocating memory for a non-coherent DMA device, the current core code removes the XP attribute, allowing code to execute from that region. This is a security vulnerability and unneeded. This change updates to mark the region as XP when allocating memory for the non-coherent DMA device.

These allocations in this function are limited to `EfiBootServicesData` and `EfiRuntimeServicesData`, which we expect to be XP.

This also updates a comment in PRM code that has a similar looking pattern, but does not clear `EFI_MEMORY_XP` because it does not pass any CPU arch attributes to the `SetMemorySpaceAttributes` which that function interprets as a request to not clear any attributes.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on QEMU and a physical platform.

## Integration Instructions

N/A.
