### PR TITLE
ci.yaml: Add PrEval entry

### DIFF
--- a/EmbeddedPkg/EmbeddedPkg.ci.yaml
+++ b/EmbeddedPkg/EmbeddedPkg.ci.yaml
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "EmbeddedPkg.dsc",
+    },
+    # MU_CHANGE end
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "skip": False,

--- a/FatPkg/FatPkg.ci.yaml
+++ b/FatPkg/FatPkg.ci.yaml
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "FatPkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/FmpDevicePkg/FmpDevicePkg.ci.yaml
+++ b/FmpDevicePkg/FmpDevicePkg.ci.yaml
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "FmpDevicePkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/PrmPkg/PrmPkg.ci.yaml
+++ b/PrmPkg/PrmPkg.ci.yaml
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "PrmPkg.dsc",
+    },
+    # MU_CHANGE end
     ## options defined .pytool/Plugin/LicenseCheck
     "LicenseCheck": {
         "IgnoreFiles": []

--- a/SecurityPkg/SecurityPkg.ci.yaml
+++ b/SecurityPkg/SecurityPkg.ci.yaml
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "SecurityPkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/SourceLevelDebugPkg/SourceLevelDebugPkg.ci.yaml
+++ b/SourceLevelDebugPkg/SourceLevelDebugPkg.ci.yaml
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "SourceLevelDebugPkg.dsc",
+    },
+    # MU_CHANGE end
     "CompilerPlugin": {
         "DscPath": "SourceLevelDebugPkg.dsc"
     },


### PR DESCRIPTION
## Description

Add PrEval entry to each package ci.yaml file, used to enable the new preval policy 5.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
