### PR TITLE
[202108] Ubuntu-GCC5.yml: Remove Scheduled Jobs

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -10,15 +10,6 @@ trigger:
 - dev/*
 - release/*
 
-schedules:
-- cron: "30 9 * * 0,3"  # Sun/Wed at 2:30AM Pacific
-  displayName: Sun/Wed Build
-  branches:
-    include:
-    - dev/*
-    - release/*
-  always: true          # Always build, even if no changes
-
 pr:
 - dev/*
 - release/*


### PR DESCRIPTION
Fixes https://github.com/microsoft/mu/issues/173

CI is currently being ran on this branch twice a week, which is wasting resources. CI only needs to be run on pull requests.