### PR TITLE
SecurityPkg/Tpm2DeviceLibTcg2: Make mTcg2Protocol static

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.c
@@ -14,7 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/Tcg2Protocol.h>
 #include <IndustryStandard/Tpm20.h>
 
-EFI_TCG2_PROTOCOL  *mTcg2Protocol = NULL;
+STATIC  EFI_TCG2_PROTOCOL  *mTcg2Protocol = NULL;
 
 /**
   This service enables the sending of commands to the TPM2.


### PR DESCRIPTION
## Description

The global variable has a common name that can conflict with other
TCG modules. For example, Tcg2Dxe has a similarly named global that
is of type EFI_TCG2_PROTOCOL instead of EFI_TCG2_PROTOCOL*.

Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jian J Wang <jian.j.wang@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
(sent to edk2 mailing list after 202308 stable tag)

https://edk2.groups.io/g/devel/message/107769

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

SecurityPkg package build.

## Integration Instructions

N/A