### PR TITLE
CodeQlFilters.yml: Glob file patterns in nested directories

### DIFF
--- a/CodeQlFilters.yml
+++ b/CodeQlFilters.yml
@@ -1,8 +1,13 @@
 ## @file
 # CodeQL Result Filters for Packages in Mu Basecore
 #
-# Note: Packages that use Mu Tiano Plus can reuse this file to quickly pick up the
-#       same filters applied to results in the Mu Tiano Plus repo.
+# Note:
+#   1. Packages that use Mu Tiano Plus can reuse this file to quickly pick up the
+#      same filters applied to results in the Mu Tiano Plus repo.
+#   2. It is recommended paths begin with `**/` in filter files residing in repos that
+#      are used as dependencies by other repos (e.g. Common/MU_TIANO). That way the filter
+#      will apply both in Mu Tiano Plus directly and regardless of where Mu Tiano Plus is
+#      located within a downstream repos directory hierarchy.
 #
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -11,7 +16,7 @@
 {
   "Filters": [
     # The NULL value passed in this file is expected by the callee
-    "-FmpDevicePkg/FmpDxe/FmpDxe.c:SM02311",
-    "-SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/DxeDebugAgentLib.c:SM02311",
+    "-**/FmpDevicePkg/FmpDxe/FmpDxe.c:SM02311",
+    "-**/SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgent/DxeDebugAgentLib.c:SM02311",
   ]
 }


### PR DESCRIPTION
## Description

This filter file is picked up both directly in `mu_tiano_plus` but also
downstream repos. Therefore, the file patterns should allow matches
regardless of where a `mu_tiano_plus` submodule or external dependency
may reside in the overall repo structure.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified local `mu_tiano_plus` CodeQL build
- Verified downstream (`mu_tiano_platforms`) CodeQL build that leverages
  the `CodeQlFilters.yml` file from `mu_tiano_plus`.

## Integration Instructions

No change in filtering behavior within `mu_tiano_plus`. Downstream repos that use
`mu_tiano_plus` will see more results auto filtered matching the expectations of
upstream repos.