### PR TITLE
SecurityPkg: Tcg2Smm: Inspect target address before usage

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -88,7 +88,8 @@ TpmNvsCommunciate (
       DEBUG ((DEBUG_VERBOSE, "[%a] - Function requested: MM_EXCHANGE_NVS_INFO\n", __FUNCTION__));
       // MU_CHANGE TCBZ4378 [BEGIN] - Check for invalid NVS buffer location
       if (IsBufferOutsideMmValid (CommParams->TargetAddress, sizeof (TCG_NVS))) {
-        DEBUG ((DEBUG_ERROR, "[%a] - NVS buffer in invalid location!\n", __FUNCTION__));
+        DEBUG ((DEBUG_ERROR, "[%a] - NVS buffer in invalid location!\n", __func__));
+
         Status = EFI_ACCESS_DENIED;
         break;
       }

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -87,7 +87,7 @@ TpmNvsCommunciate (
     case TpmNvsMmExchangeInfo:
       DEBUG ((DEBUG_VERBOSE, "[%a] - Function requested: MM_EXCHANGE_NVS_INFO\n", __FUNCTION__));
       // MU_CHANGE TCBZ4378 [BEGIN] - Check for invalid NVS buffer location
-      if (IsBufferOutsideMmValid (CommParams->TargetAddress, sizeof (TCG_NVS))) {
+      if (!IsBufferOutsideMmValid (CommParams->TargetAddress, sizeof (TCG_NVS))) {
         DEBUG ((DEBUG_ERROR, "[%a] - NVS buffer in invalid location!\n", __func__));
 
         Status = EFI_ACCESS_DENIED;

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -93,6 +93,7 @@ TpmNvsCommunciate (
         Status = EFI_ACCESS_DENIED;
         break;
       }
+
       // MU_CHANGE TCBZ4378 [END]
       CommParams->RegisteredPpSwiValue = mPpSoftwareSmi;
       CommParams->RegisteredMcSwiValue = mMcSoftwareSmi;

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -86,6 +86,13 @@ TpmNvsCommunciate (
   switch (CommParams->Function) {
     case TpmNvsMmExchangeInfo:
       DEBUG ((DEBUG_VERBOSE, "[%a] - Function requested: MM_EXCHANGE_NVS_INFO\n", __FUNCTION__));
+      // MU_CHANGE TCBZ4378 [BEGIN] - Check for invalid NVS buffer location
+      if (IsBufferOutsideMmValid (CommParams->TargetAddress, sizeof (TCG_NVS))) {
+        DEBUG ((DEBUG_ERROR, "[%a] - NVS buffer in invalid location!\n", __FUNCTION__));
+        Status = EFI_ACCESS_DENIED;
+        break;
+      }
+      // MU_CHANGE TCBZ4378 [END]
       CommParams->RegisteredPpSwiValue = mPpSoftwareSmi;
       CommParams->RegisteredMcSwiValue = mMcSoftwareSmi;
       mTcgNvs                          = (TCG_NVS *)(UINTN)CommParams->TargetAddress;


### PR DESCRIPTION
## Description

This change uses abstracted interface from MemLib to validate incoming nested pointer before usage to ensure user supplied legitimate NVS buffer for corresponding TCG operations.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change is validated on proprietary hardware platform.

## Integration Instructions

N/A