### PR TITLE
[CHERRY-PICK] SecurityPkg: Apply uncrustify formatting to relevant files

### DIFF
--- a/SecurityPkg/Library/SecureBootVariableLib/GoogleTest/SecureBootVariableLibGoogleTest.cpp
+++ b/SecurityPkg/Library/SecureBootVariableLib/GoogleTest/SecureBootVariableLibGoogleTest.cpp
@@ -21,154 +21,189 @@ using namespace testing;
 
 //////////////////////////////////////////////////////////////////////////////
 class SetSecureBootModeTest : public Test {
-  protected:
-    MockUefiRuntimeServicesTableLib RtServicesMock;
-    UINT8       SecureBootMode;
-    EFI_STATUS  Status;
+protected:
+  MockUefiRuntimeServicesTableLib RtServicesMock;
+  UINT8 SecureBootMode;
+  EFI_STATUS Status;
 
-    void SetUp() override {
-      // Any random magic number can be used for these tests
-      SecureBootMode = 0xAB;
-    }
+  void
+  SetUp (
+    ) override
+  {
+    // Any random magic number can be used for these tests
+    SecureBootMode = 0xAB;
+  }
 };
 
 // Test SetSecureBootMode() API from SecureBootVariableLib to verify the
 // expected error is returned when the call to gRT->SetVariable() fails.
-TEST_F(SetSecureBootModeTest, SetVarError) {
-  EXPECT_CALL(RtServicesMock, gRT_SetVariable)
-    .WillOnce(Return(EFI_INVALID_PARAMETER));
+TEST_F (SetSecureBootModeTest, SetVarError) {
+  EXPECT_CALL (RtServicesMock, gRT_SetVariable)
+    .WillOnce (Return (EFI_INVALID_PARAMETER));
 
-  Status = SetSecureBootMode(SecureBootMode);
-  EXPECT_EQ(Status, EFI_INVALID_PARAMETER);
+  Status = SetSecureBootMode (SecureBootMode);
+  EXPECT_EQ (Status, EFI_INVALID_PARAMETER);
 }
 
 // Test SetSecureBootMode() API from SecureBootVariableLib to verify the
 // expected secure boot mode is written to the correct variable in the call
 // to gRT->SetVariable().
-TEST_F(SetSecureBootModeTest, PropogateModeToSetVar) {
-  EXPECT_CALL(RtServicesMock,
-    gRT_SetVariable(
-      Char16StrEq(EFI_CUSTOM_MODE_NAME),
-      BufferEq(&gEfiCustomModeEnableGuid, sizeof(EFI_GUID)),
+TEST_F (SetSecureBootModeTest, PropogateModeToSetVar) {
+  EXPECT_CALL (
+    RtServicesMock,
+    gRT_SetVariable (
+      Char16StrEq (EFI_CUSTOM_MODE_NAME),
+      BufferEq (&gEfiCustomModeEnableGuid, sizeof (EFI_GUID)),
       EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
-      sizeof(SecureBootMode),
-      BufferEq(&SecureBootMode, sizeof(SecureBootMode))))
-    .WillOnce(Return(EFI_SUCCESS));
+      sizeof (SecureBootMode),
+      BufferEq (&SecureBootMode, sizeof (SecureBootMode))
+      )
+    )
+    .WillOnce (Return (EFI_SUCCESS));
 
-  Status = SetSecureBootMode(SecureBootMode);
-  EXPECT_EQ(Status, EFI_SUCCESS);
+  Status = SetSecureBootMode (SecureBootMode);
+  EXPECT_EQ (Status, EFI_SUCCESS);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 class GetSetupModeTest : public Test {
-  protected:
-    MockUefiRuntimeServicesTableLib RtServicesMock;
-    UINT8       SetupMode;
-    EFI_STATUS  Status;
-    UINT8       ExpSetupMode;
+protected:
+  MockUefiRuntimeServicesTableLib RtServicesMock;
+  UINT8 SetupMode;
+  EFI_STATUS Status;
+  UINT8 ExpSetupMode;
 
-    void SetUp() override {
-      // Any random magic number can be used for these tests
-      ExpSetupMode = 0xAB;
-    }
+  void
+  SetUp (
+    ) override
+  {
+    // Any random magic number can be used for these tests
+    ExpSetupMode = 0xAB;
+  }
 };
 
 // Test GetSetupMode() API from SecureBootVariableLib to verify the expected
 // error is returned when the call to gRT->GetVariable() fails.
-TEST_F(GetSetupModeTest, GetVarError) {
-  EXPECT_CALL(RtServicesMock, gRT_GetVariable)
-    .WillOnce(Return(EFI_INVALID_PARAMETER));
+TEST_F (GetSetupModeTest, GetVarError) {
+  EXPECT_CALL (RtServicesMock, gRT_GetVariable)
+    .WillOnce (Return (EFI_INVALID_PARAMETER));
 
   Status = GetSetupMode (&SetupMode);
-  EXPECT_EQ(Status, EFI_INVALID_PARAMETER);
+  EXPECT_EQ (Status, EFI_INVALID_PARAMETER);
 }
 
 // Test GetSetupMode() API from SecureBootVariableLib to verify the expected
 // setup mode is returned (and with a success return code) when the mode is
 // successfully read from the call to gRT->GetVariable().
-TEST_F(GetSetupModeTest, FetchModeFromGetVar) {
-  EXPECT_CALL(RtServicesMock,
-    gRT_GetVariable(
-      Char16StrEq(EFI_SETUP_MODE_NAME),
-      BufferEq(&gEfiGlobalVariableGuid, sizeof(EFI_GUID)),
+TEST_F (GetSetupModeTest, FetchModeFromGetVar) {
+  EXPECT_CALL (
+    RtServicesMock,
+    gRT_GetVariable (
+      Char16StrEq (EFI_SETUP_MODE_NAME),
+      BufferEq (&gEfiGlobalVariableGuid, sizeof (EFI_GUID)),
       _,
-      Pointee(Eq(sizeof(SetupMode))),
-      NotNull()))
-    .WillOnce(DoAll(
-      SetArgPointee<3>(sizeof(ExpSetupMode)),
-      SetArgBuffer<4>(&ExpSetupMode, sizeof(ExpSetupMode)),
-      Return(EFI_SUCCESS)));
+      Pointee (Eq (sizeof (SetupMode))),
+      NotNull ()
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgPointee<3>(sizeof (ExpSetupMode)),
+         SetArgBuffer<4>(&ExpSetupMode, sizeof (ExpSetupMode)),
+         Return (EFI_SUCCESS)
+         )
+       );
 
   Status = GetSetupMode (&SetupMode);
-  ASSERT_EQ(Status, EFI_SUCCESS);
-  EXPECT_EQ(SetupMode, ExpSetupMode);
+  ASSERT_EQ (Status, EFI_SUCCESS);
+  EXPECT_EQ (SetupMode, ExpSetupMode);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 class IsSecureBootEnabledTest : public Test {
-  protected:
-    MockUefiLib UefiLibMock;
-    BOOLEAN     Enabled;
+protected:
+  MockUefiLib UefiLibMock;
+  BOOLEAN Enabled;
 };
 
 // Test IsSecureBootEnabled() API from SecureBootVariableLib to verify FALSE
 // is returned when the call to GetEfiGlobalVariable2() fails.
-TEST_F(IsSecureBootEnabledTest, GetVarError) {
-  EXPECT_CALL(UefiLibMock, GetEfiGlobalVariable2)
-    .WillOnce(Return(EFI_ABORTED));
+TEST_F (IsSecureBootEnabledTest, GetVarError) {
+  EXPECT_CALL (UefiLibMock, GetEfiGlobalVariable2)
+    .WillOnce (Return (EFI_ABORTED));
 
   Enabled = IsSecureBootEnabled ();
-  EXPECT_EQ(Enabled, FALSE);
+  EXPECT_EQ (Enabled, FALSE);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 class IsSecureBootEnabledAllocTest : public IsSecureBootEnabledTest {
-  protected:
-    UINT8 *BootEnabledBuffer;
+protected:
+  UINT8 *BootEnabledBuffer;
 
-    void SetUp() override {
-      BootEnabledBuffer = (UINT8*) AllocatePool(1);
-      ASSERT_NE(BootEnabledBuffer, nullptr);
-    }
+  void
+  SetUp (
+    ) override
+  {
+    BootEnabledBuffer = (UINT8 *)AllocatePool (1);
+    ASSERT_NE (BootEnabledBuffer, nullptr);
+  }
 };
 
 // Test IsSecureBootEnabled() API from SecureBootVariableLib to verify TRUE
 // is returned when the call to GetEfiGlobalVariable2() is successful and
 // returns SECURE_BOOT_MODE_ENABLE.
-TEST_F(IsSecureBootEnabledAllocTest, IsEnabled) {
+TEST_F (IsSecureBootEnabledAllocTest, IsEnabled) {
   *BootEnabledBuffer = SECURE_BOOT_MODE_ENABLE;
-  EXPECT_CALL(UefiLibMock,
-    GetEfiGlobalVariable2(
-      Char16StrEq(EFI_SECURE_BOOT_MODE_NAME),
-      NotNull(),
-      _))
-    .WillOnce(DoAll(
-      SetArgBuffer<1>(&BootEnabledBuffer, sizeof(VOID*)),
-      Return(EFI_SUCCESS)));
+  EXPECT_CALL (
+    UefiLibMock,
+    GetEfiGlobalVariable2 (
+      Char16StrEq (EFI_SECURE_BOOT_MODE_NAME),
+      NotNull (),
+      _
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgBuffer<1>(&BootEnabledBuffer, sizeof (VOID *)),
+         Return (EFI_SUCCESS)
+         )
+       );
 
   Enabled = IsSecureBootEnabled ();
-  EXPECT_EQ(Enabled, TRUE);
+  EXPECT_EQ (Enabled, TRUE);
 }
 
 // Test IsSecureBootEnabled() API from SecureBootVariableLib to verify FALSE
 // is returned when the call to GetEfiGlobalVariable2() is successful and
 // returns SECURE_BOOT_MODE_DISABLE.
-TEST_F(IsSecureBootEnabledAllocTest, IsDisabled) {
+TEST_F (IsSecureBootEnabledAllocTest, IsDisabled) {
   *BootEnabledBuffer = SECURE_BOOT_MODE_DISABLE;
-  EXPECT_CALL(UefiLibMock,
-    GetEfiGlobalVariable2(
-      Char16StrEq(EFI_SECURE_BOOT_MODE_NAME),
-      NotNull(),
-      _))
-    .WillOnce(DoAll(
-      SetArgBuffer<1>(&BootEnabledBuffer, sizeof(VOID*)),
-      Return(EFI_SUCCESS)));
+  EXPECT_CALL (
+    UefiLibMock,
+    GetEfiGlobalVariable2 (
+      Char16StrEq (EFI_SECURE_BOOT_MODE_NAME),
+      NotNull (),
+      _
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgBuffer<1>(&BootEnabledBuffer, sizeof (VOID *)),
+         Return (EFI_SUCCESS)
+         )
+       );
 
   Enabled = IsSecureBootEnabled ();
-  EXPECT_EQ(Enabled, FALSE);
+  EXPECT_EQ (Enabled, FALSE);
 }
 
-int main(int argc, char* argv[]) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
 }

--- a/SecurityPkg/Test/Mock/Include/GoogleTest/Library/MockPlatformPKProtectionLib.h
+++ b/SecurityPkg/Test/Mock/Include/GoogleTest/Library/MockPlatformPKProtectionLib.h
@@ -11,8 +11,8 @@
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
 extern "C" {
-#include <Uefi.h>
-#include <Library/PlatformPKProtectionLib.h>
+  #include <Uefi.h>
+  #include <Library/PlatformPKProtectionLib.h>
 }
 
 struct MockPlatformPKProtectionLib {

--- a/SecurityPkg/Test/Mock/Library/GoogleTest/MockPlatformPKProtectionLib/MockPlatformPKProtectionLib.cpp
+++ b/SecurityPkg/Test/Mock/Library/GoogleTest/MockPlatformPKProtectionLib/MockPlatformPKProtectionLib.cpp
@@ -6,6 +6,6 @@
 **/
 #include <GoogleTest/Library/MockPlatformPKProtectionLib.h>
 
-MOCK_INTERFACE_DEFINITION(MockPlatformPKProtectionLib);
+MOCK_INTERFACE_DEFINITION (MockPlatformPKProtectionLib);
 
-MOCK_FUNCTION_DEFINITION(MockPlatformPKProtectionLib, DisablePKProtection, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPlatformPKProtectionLib, DisablePKProtection, 0, EFIAPI);


### PR DESCRIPTION
## Description

Updating Mu projects to apply uncrusty formatting for Cpp and header files, config updated upstream in edk2 https://github.com/tianocore/edk2/pull/4957 .

Config will be updated in mu_basecore https://github.com/microsoft/mu_basecore/pull/609.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Breaks Uncrustify check on header file. Dependent on Uncrustify update in mu_basecore (https://github.com/microsoft/mu_basecore/pull/609)
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Local CI build using a local mu_basecore branch with the Uncrustify config changes.

## Integration Instructions

Project needs update mu_basecore with config changes.
