### PR TITLE
.git-blame-ignore-revs: Ignore Line Ending and Uncrustify only commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,25 @@
+###################################################
+# Line Ending Only Changes                        #
+###################################################
+# Merged PR 6167: Updated file line endings to CRLF
+749591b633658c34b74bf485f63f95789c75395c
+# Convert line endings from LF to CRLF
+1c9774f16fbe898f26841711cf08fc4c941f1e82
+
+###################################################
+# Code Formatting (Uncrustify) Only Changes       #
+###################################################
+# [CHERRY-PICK] SecurityPkg: Apply uncrustify formatting to relevant files
+48e292c218697ad90dda70125229a3ba3cd7e5c4
+# SourceLevelDebugPkg: Apply uncrustify changes
+c1e126b1196de75e0a4cda21e4551ea9bb05e059
+# SecurityPkg: Apply uncrustify changes
+c411b485b63a671a1e276700cff025c73997233c
+# PrmPkg: Apply uncrustify changes
+a298a84478053872ed9da660a75f182ce81b8ddc
+# FmpDevicePkg: Apply uncrustify changes
+45ce0a67bb4ee80f27da93777c623f51f344f23b
+# FatPkg: Apply uncrustify changes
+bcdcc4160d7460c46c08c9395aae81be44ef23a9
+# EmbeddedPkg: Apply uncrustify changes
+e7108d0e9655b1795c94ac372b0449f28dd907df


### PR DESCRIPTION
## Description

Adds commits that only applied Uncrustify formatting or converted
line endings to a .git-blame-ignore-revs file so they are ignored
by git blame. This is supported by GitHub:
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/

This helps clean up git blame by filtering out these changes.

Note: This file needs to be updated on rebase branches. Processes
      like filter-branch can automatically update relevant SHAs.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- `git blame`

## Integration Instructions

N/A