### PR TITLE
[CHERRY-PICK] RNG Related Commits (Needed for Arm RngDxe to Work) [Rebase & FF]

### DIFF
--- a/SecurityPkg/RandomNumberGenerator/RngDxe/AArch64/AArch64Algo.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/AArch64/AArch64Algo.c
@@ -10,6 +10,8 @@
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/ArmTrngLib.h>
+#include <Library/RngLib.h>
+#include <Guid/RngAlgorithm.h>
 
 #include "RngDxeInternals.h"
 
@@ -28,9 +30,13 @@ GetAvailableAlgorithms (
   VOID
   )
 {
-  UINT64  DummyRand;
-  UINT16  MajorRevision;
-  UINT16  MinorRevision;
+  EFI_STATUS  Status;
+  UINT16      MajorRevision;
+  UINT16      MinorRevision;
+  GUID        RngGuid;
+  BOOLEAN     UnSafeAlgo;
+
+  UnSafeAlgo = FALSE;
 
   // Rng algorithms 2 times, one for the allocation, one to populate.
   mAvailableAlgoArray = AllocateZeroPool (RNG_AVAILABLE_ALGO_MAX * sizeof (EFI_RNG_ALGORITHM));
@@ -38,24 +44,28 @@ GetAvailableAlgorithms (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  // Check RngGetBytes() before advertising PcdCpuRngSupportedAlgorithm.
-  if (!EFI_ERROR (RngGetBytes (sizeof (DummyRand), (UINT8 *)&DummyRand))) {
-    CopyMem (
-      &mAvailableAlgoArray[mAvailableAlgoArrayCount],
-      PcdGetPtr (PcdCpuRngSupportedAlgorithm),
-      sizeof (EFI_RNG_ALGORITHM)
-      );
-    mAvailableAlgoArrayCount++;
-
-    if (IsZeroGuid (PcdGetPtr (PcdCpuRngSupportedAlgorithm))) {
-      DEBUG_CODE_BEGIN ();
+  // Identify RngLib algorithm.
+  Status = GetRngGuid (&RngGuid);
+  if (!EFI_ERROR (Status)) {
+    if (IsZeroGuid (&RngGuid) ||
+        CompareGuid (&RngGuid, &gEdkiiRngAlgorithmUnSafe))
+    {
+      // Treat zero GUID as an unsafe algorithm
       DEBUG ((
         DEBUG_WARN,
-        "PcdCpuRngSupportedAlgorithm should be a non-zero GUID\n"
+        "RngLib uses an Unsafe algorithm and "
+        "must not be used for production builds.\n"
         ));
-
-      DEBUG_CODE_END ();
-      mAvailableAlgoArrayCount--;
+      // Set the UnSafeAlgo flag to indicate an unsafe algorithm was found
+      // so that it can be added at the end of the algorithm list.
+      UnSafeAlgo = TRUE;
+    } else {
+      CopyMem (
+        &mAvailableAlgoArray[mAvailableAlgoArrayCount],
+        &RngGuid,
+        sizeof (RngGuid)
+        );
+      mAvailableAlgoArrayCount++;
     }
   }
 
@@ -64,6 +74,16 @@ GetAvailableAlgorithms (
     CopyMem (
       &mAvailableAlgoArray[mAvailableAlgoArrayCount],
       &gEfiRngAlgorithmRaw,
+      sizeof (EFI_RNG_ALGORITHM)
+      );
+    mAvailableAlgoArrayCount++;
+  }
+
+  // Add unsafe algorithm at the end of the list.
+  if (UnSafeAlgo) {
+    CopyMem (
+      &mAvailableAlgoArray[mAvailableAlgoArrayCount],
+      &gEdkiiRngAlgorithmUnSafe,
       sizeof (EFI_RNG_ALGORITHM)
       );
     mAvailableAlgoArrayCount++;

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/ArmRngDxe.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/ArmRngDxe.c
@@ -78,6 +78,7 @@ RngGetRNG (
 {
   EFI_STATUS  Status;
   UINTN       Index;
+  GUID        RngGuid;
 
   if ((This == NULL) || (RNGValueLength == 0) || (RNGValue == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -102,7 +103,10 @@ RngGetRNG (
   }
 
 FoundAlgo:
-  if (CompareGuid (RNGAlgorithm, PcdGetPtr (PcdCpuRngSupportedAlgorithm))) {
+  Status = GetRngGuid (&RngGuid);
+  if (!EFI_ERROR (Status) &&
+      CompareGuid (RNGAlgorithm, &RngGuid))
+  {
     Status = RngGetBytes (RNGValueLength, RNGValue);
     return Status;
   }

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/ArmRngDxe.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/ArmRngDxe.c
@@ -77,7 +77,6 @@ RngGetRNG (
   )
 {
   EFI_STATUS  Status;
-  UINTN       Index;
   GUID        RngGuid;
 
   if ((This == NULL) || (RNGValueLength == 0) || (RNGValue == NULL)) {
@@ -88,21 +87,13 @@ RngGetRNG (
     //
     // Use the default RNG algorithm if RNGAlgorithm is NULL.
     //
-    for (Index = 0; Index < mAvailableAlgoArrayCount; Index++) {
-      if (!IsZeroGuid (&mAvailableAlgoArray[Index])) {
-        RNGAlgorithm = &mAvailableAlgoArray[Index];
-        goto FoundAlgo;
-      }
-    }
-
-    if (Index == mAvailableAlgoArrayCount) {
-      // No algorithm available.
-      ASSERT (Index != mAvailableAlgoArrayCount);
-      return EFI_DEVICE_ERROR;
+    if (mAvailableAlgoArrayCount != 0) {
+      RNGAlgorithm = &mAvailableAlgoArray[0];
+    } else {
+      return EFI_UNSUPPORTED;
     }
   }
 
-FoundAlgo:
   Status = GetRngGuid (&RngGuid);
   if (!EFI_ERROR (Status) &&
       CompareGuid (RNGAlgorithm, &RngGuid))

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
@@ -79,8 +79,8 @@
 [Protocols]
   gEfiRngProtocolGuid                ## PRODUCES
 
-[Pcd]
-  gEfiSecurityPkgTokenSpaceGuid.PcdCpuRngSupportedAlgorithm      ## CONSUMES
+[Pcd.AARCH64]
+  gEfiMdePkgTokenSpaceGuid.PcdCpuRngSupportedAlgorithm      ## CONSUMES
 
 [Depex]
   TRUE

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
@@ -75,12 +75,10 @@
   gEfiRngAlgorithmX9313DesGuid        ## SOMETIMES_PRODUCES    ## GUID        # Unique ID of the algorithm for RNG
   gEfiRngAlgorithmX931AesGuid         ## SOMETIMES_PRODUCES    ## GUID        # Unique ID of the algorithm for RNG
   gEfiRngAlgorithmRaw                 ## SOMETIMES_PRODUCES    ## GUID        # Unique ID of the algorithm for RNG
+  gEdkiiRngAlgorithmUnSafe            ## SOMETIMES_PRODUCES    ## GUID        # Unique ID of the algorithm for RNG
 
 [Protocols]
   gEfiRngProtocolGuid                ## PRODUCES
-
-[Pcd.AARCH64]
-  gEfiMdePkgTokenSpaceGuid.PcdCpuRngSupportedAlgorithm      ## CONSUMES
 
 [Depex]
   TRUE

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -363,8 +363,6 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeFvVerificationPass|0x0303100A|UINT32|0x00010030
   gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeFvVerificationFail|0x0303100B|UINT32|0x00010031
 
-  gEfiSecurityPkgTokenSpaceGuid.PcdCpuRngSupportedAlgorithm|{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}|VOID*|0x00010032
-
   ## MS_CHANGE_?
   ## This fixed at build flag tells the TPM stack whether to update the TPM allocation if a
   #  mismatch is found between PcdTpm2HashMask and the active banks.


### PR DESCRIPTION
## Description

---

[CHERRY-PICK] SecurityPkg/SecurityPkg.dec: Move PcdCpuRngSupportedAlgorithm to MdePkg

In order to use PcdCpuRngSupportedAlgorithm in the MdePkg in a
following patch and to avoid making the MdePkg dependent on another
package, move PcdCpuRngSupportedAlgorithm to the MdePkg.

As the Pcd is only used for AARCH64, place it in an AARCH64
specific sections.

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>
Acked-by: Jiewen Yao <Jiewen.yao@intel.com>
Tested-by: Kun Qin <kun.qin@microsoft.com>
(cherry picked from commit 65b5dd828ef2ea5056031b239a4e7a6642f771a3)

---

[CHERRY-PICK] SecurityPkg/RngDxe: Simplify Rng algorithm selection for Arm

The first element of mAvailableAlgoArray is defined as the default
Rng algorithm to use. Don't go through the array at each RngGetRNG()
call and just return the first element of the array.

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>
Acked-by: Jiewen Yao <Jiewen.yao@intel.com>
Tested-by: Kun Qin <kun.qin@microsoft.com>
(cherry picked from commit ff7ddc02b273f9159ef46fdb67d99062f8e598d9)

---

[CHERRY-PICK] SecurityPkg/RngDxe: Use GetRngGuid() when probing RngLib

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4151

The EFI_RNG_PROTOCOL can rely on the RngLib. The RngLib has multiple
implementations, some of them are unsafe (e.g. BaseRngLibTimerLib).
To allow the RngDxe to detect when such implementation is used,
a GetRngGuid() function was added in a previous patch.

The EFI_RNG_PROTOCOL can advertise multiple algorithms through
Guids. The PcdCpuRngSupportedAlgorithm is currently used to
advertise the RngLib in the Arm implementation.

The issues of doing that are:
- the RngLib implementation might not use CPU instructions,
  cf. the BaseRngLibTimerLib
- most platforms don't set PcdCpuRngSupportedAlgorithm

A GetRngGuid() was added to the RngLib in a previous patch,
allowing to identify the algorithm implemented by the RngLib.
Make use of this function and place the unsage algorithm
at the last position in the mAvailableAlgoArray.

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>
Acked-by: Jiewen Yao <Jiewen.yao@intel.com>
Tested-by: Kun Qin <kun.qin@microsoft.com>
(cherry picked from commit 19438cff973bfb35a1ef12fab45fabb28b63fe64)

---

[CHERRY-PICK] SecurityPkg/SecurityPkg.dec: Move PcdCpuRngSupportedAlgorithm to MdePkg

In order to use PcdCpuRngSupportedAlgorithm in the MdePkg in a
following patch and to avoid making the MdePkg dependent on another
package, move PcdCpuRngSupportedAlgorithm to the MdePkg.

As the Pcd is only used for AARCH64, place it in an AARCH64
specific sections.

Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Acked-by: Ard Biesheuvel <ardb@kernel.org>
Acked-by: Jiewen Yao <Jiewen.yao@intel.com>
Tested-by: Kun Qin <kun.qin@microsoft.com>
(cherry picked from commit 65b5dd828ef2ea5056031b239a4e7a6642f771a3)

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Mu Basecore CI.
- Build QemuQ35Pkg and QemuSbsaPkg IA32, X64, and AARCH64 with the changes.
- Leverage edk2 upstream testing.

## Integration Instructions

- Use the `gEdkiiRngAlgorithmUnSafe` if needed to integrate other code changes.