### PR TITLE
Added NULL implementation for Tcg2PreUefiEventLogLib

### DIFF
--- a/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.c
+++ b/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.c
@@ -1,17 +1,16 @@
 /** @file Tcg2PreUefiEventLogLibNull.c
-NOTE: NULL Tcg2PreUefiEventLogLibNull library instance
+ NULL Tcg2PreUefiEventLogLibNull library instance
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <Library/DebugLib.h>
-
 /**
   Create the EventLog entries.
 **/
 VOID
+EFIAPI
 CreateTcg2PreUefiEventLogEntries (
   VOID
   )

--- a/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.c
+++ b/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.c
@@ -1,0 +1,20 @@
+/** @file Tcg2PreUefiEventLogLibNull.c
+NOTE: NULL Tcg2PreUefiEventLogLibNull library instance
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+
+/**
+  Create the EventLog entries.
+**/
+VOID
+CreateTcg2PreUefiEventLogEntries (
+  VOID
+  )
+{
+  return;
+}

--- a/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
+++ b/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
@@ -1,0 +1,34 @@
+## @file Tcg2PreUefiEventLogLibNull.inf
+# NULL Tcg2PreUefiEventLogLibNull library instance
+#
+##
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = Tcg2PreUefiEventLogLibNull
+  FILE_GUID           = 707A99A0-16FA-4D3C-A033-4568EB40A356
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = BASE
+  LIBRARY_CLASS       = Tcg2PreUefiEventLogLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+
+[Sources]
+  Tcg2PreUefiEventLogLibNull.c
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+
+[LibraryClasses]
+  DebugLib

--- a/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
+++ b/SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
@@ -1,5 +1,5 @@
 ## @file Tcg2PreUefiEventLogLibNull.inf
-# NULL Tcg2PreUefiEventLogLibNull library instance
+# Tcg2PreUefiEventLogLib Null library instance
 #
 ##
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -28,7 +28,3 @@
 
 [Packages]
   MdePkg/MdePkg.dec
-
-
-[LibraryClasses]
-  DebugLib

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -81,10 +81,9 @@
   SourceDebugEnabledLib|SourceLevelDebugPkg/Library/SourceDebugEnabled/SourceDebugEnabledLib.inf ## MS_CHANGE_?
   Hash2CryptoLib|SecurityPkg/Library/BaseHash2CryptoLibNull/BaseHash2CryptoLibNull.inf   ## MU_CHANGE
   SafeIntLib |MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf ## MU_CHANGE - CodeQL change
-  Tcg2PreUefiEventLogLib|SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf  ## MU_CHANGE
-
-  ## MU_CHANGE TEMP
+  
 [LibraryClasses.X64, LibraryClasses.IA32]
+  Tcg2PreUefiEventLogLib|SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf  ## MU_CHANGE
   
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   #

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -81,12 +81,11 @@
   SourceDebugEnabledLib|SourceLevelDebugPkg/Library/SourceDebugEnabled/SourceDebugEnabledLib.inf ## MS_CHANGE_?
   Hash2CryptoLib|SecurityPkg/Library/BaseHash2CryptoLibNull/BaseHash2CryptoLibNull.inf   ## MU_CHANGE
   SafeIntLib |MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf ## MU_CHANGE - CodeQL change
+  Tcg2PreUefiEventLogLib|SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf  ## MU_CHANGE
 
   ## MU_CHANGE TEMP
 [LibraryClasses.X64, LibraryClasses.IA32]
-  ## NOTE: This is a temporary shim to resolve a build error while a more permanent solution is tested!
-  Tcg2PreUefiEventLogLib|SecurityPkg/Library/TempPreUefiEventLogLib/TempPreUefiEventLogLib.inf
-
+  
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   #
   # It is not possible to prevent the ARM compiler for generic intrinsic functions.
@@ -312,6 +311,7 @@
   SecurityPkg/Library/TempPreUefiEventLogLib/TempPreUefiEventLogLib.inf
   SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
   SecurityPkg/Library/Tcg2PhysicalPresencePromptLib/Tcg2PhysicalPresencePromptLibConsole.inf
+  SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
 ## MS_CHANGE END
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]


### PR DESCRIPTION
## Description

Added NULL implementation for Tcg2PreUefiEventLogLib

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Consumed this null library under C41A8 project and verified Build successful

## Integration Instructions

N/A