### PR TITLE
Corrects spelling error in unit test

### DIFF
--- a/SecurityPkg/Library/DxeTpmMeasureBootLib/InternalUnitTest/DxeTpmMeasureBootLibSanitizationTest.c
+++ b/SecurityPkg/Library/DxeTpmMeasureBootLib/InternalUnitTest/DxeTpmMeasureBootLibSanitizationTest.c
@@ -287,7 +287,7 @@ TestSanitizePeImageEventSize (
   // Test that the event size may not overflow
   Status = TpmSanitizePeImageEventSize (MAX_UINT32, &EventSize);
   if (Status != EFI_BAD_BUFFER_SIZE) {
-    UT_LOG_ERROR ("TpmSanitizePeImageEventSize succeded when it was supposed to fail with %r\n", Status);
+    UT_LOG_ERROR ("TpmSanitizePeImageEventSize succeeded when it was supposed to fail with %r\n", Status);
     goto Exit;
   }
 


### PR DESCRIPTION
# Preface

## Description

Pipeline just started picking up a spelling mistake in a log message in a unit test

- [ ] Impacts functionality?
  - **Functionality** - No
- [ ] Impacts security?
  - **Security** - No
- [ ] Breaking change?
  - **Breaking change** - No
- [ ] Includes tests?
  - **Tests** - No
- [ ] Includes documentation?
  - **Documentation** - No
## How This Was Tested

N/A

## Integration Instructions

N/A