### PR TITLE
Add an assert to TCG log function if log is full

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -871,7 +871,7 @@ TcgCommLogEvent (
     DEBUG ((DEBUG_INFO, "  NewLogSize - 0x%x\n", NewLogSize));
     DEBUG ((DEBUG_INFO, "  LogSize    - 0x%x\n", EventLogAreaStruct->EventLogSize));
     DEBUG ((DEBUG_INFO, "TcgCommLogEvent - %r\n", EFI_OUT_OF_RESOURCES));
-    ASSERT(FALSE); // MU_CHANGE: Assert to catch systematic TCG log truncation during DEBUG testing.
+    ASSERT (FALSE); // MU_CHANGE: Assert to catch systematic TCG log truncation during DEBUG testing.
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -871,6 +871,7 @@ TcgCommLogEvent (
     DEBUG ((DEBUG_INFO, "  NewLogSize - 0x%x\n", NewLogSize));
     DEBUG ((DEBUG_INFO, "  LogSize    - 0x%x\n", EventLogAreaStruct->EventLogSize));
     DEBUG ((DEBUG_INFO, "TcgCommLogEvent - %r\n", EFI_OUT_OF_RESOURCES));
+    ASSERT(FALSE); // MU_CHANGE: Assert to catch systematic TCG log truncation during DEBUG testing.
     return EFI_OUT_OF_RESOURCES;
   }
 


### PR DESCRIPTION
## Description

Currently, if the TCG log fills up, the firmware will boot only logging some errors and the OS may or may not fail depending on scenario and configuration. This PR adds an assert so that these truncations can be found in testing rather then having to wait for failures in production.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
