### PR TITLE
Addeding dTPM support for MM Core module type

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
@@ -22,7 +22,7 @@
   FILE_GUID                      = 9A5DB21A-FF0B-46D0-8672-B4F83FEF1F0E
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = Tpm2DeviceLib|MM_STANDALONE MM_CORE_STANDALONE
+  LIBRARY_CLASS                  = Tpm2DeviceLib|MM_STANDALONE MM_CORE_STANDALONE # MU_CHANGE
   CONSTRUCTOR                    = Tpm2DeviceLibConstructor
 
 #

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmStandaloneMm.inf
@@ -22,7 +22,7 @@
   FILE_GUID                      = 9A5DB21A-FF0B-46D0-8672-B4F83FEF1F0E
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = Tpm2DeviceLib|MM_STANDALONE
+  LIBRARY_CLASS                  = Tpm2DeviceLib|MM_STANDALONE MM_CORE_STANDALONE
   CONSTRUCTOR                    = Tpm2DeviceLibConstructor
 
 #


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The current dTPM library instance only supports MM_STANDALONE, which makes the MM core module unable to use this instance.

This change expands the support for this library to cover MM_CORE_STANDALONE as well.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35 and verified bootable to UEFI shell.

## Integration Instructions

N/A
