### PR TITLE
SecurityPkg: Temporarily remove DeviceSecurity (and libspdm) from build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "SecurityPkg/DeviceSecurity/SpdmLib/libspdm"]
-	path = SecurityPkg/DeviceSecurity/SpdmLib/libspdm
-	url = https://github.com/DMTF/libspdm.git

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -7,5 +7,11 @@
 # Ignore cloned dependencies
 /MU_BASECORE
 
+# MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
+#                    submodule in the libspdm submodule is stable
+#                    (on github)
 # Ignore libspdm submodule
-/SecurityPkg/DeviceSecurity/SpdmLib/libspdm
+# /SecurityPkg/DeviceSecurity/SpdmLib/libspdm
+# MU_CHANGE [END]: Remove SPDM from the build until the cmocka
+#                  submodule in the libspdm submodule is stable
+#                  (on github)

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -171,8 +171,14 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         If no RequiredSubmodules return an empty iterable
         '''
         rs = []
-        rs.append(RequiredSubmodule(
-            "SecurityPkg/DeviceSecurity/SpdmLib/libspdm", False))
+        # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
+        #                    submodule in the libspdm submodule is stable
+        #                    (on github)
+        # rs.append(RequiredSubmodule(
+        #     "SecurityPkg/DeviceSecurity/SpdmLib/libspdm", False))
+        # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
+        #                  submodule in the libspdm submodule is stable
+        #                  (on github)
         return rs
 
     def GetName(self):

--- a/SecurityPkg/SecurityPkg.ci.yaml
+++ b/SecurityPkg/SecurityPkg.ci.yaml
@@ -68,7 +68,15 @@
     },
     "DscCompleteCheck": {
         "DscPath": "SecurityPkg.dsc",
-        "IgnoreInf": []
+        "IgnoreInf": [
+            # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
+            #                    submodule in the libspdm submodule is stable
+            #                    (on github)
+            SecurityPkg/DeviceSecurity/**
+            # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
+            #                  submodule in the libspdm submodule is stable
+            #                  (on github)
+        ]
     },
     ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
     "HostUnitTestDscCompleteCheck": {
@@ -86,7 +94,13 @@
     "LibraryClassCheck": {
         "IgnoreHeaderFile": [
             "DeviceSecurity/SpdmLib/Include/library",
-            "DeviceSecurity/SpdmLib/libspdm/include/library",
+            # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
+            #                    submodule in the libspdm submodule is stable
+            #                    (on github)
+            # "DeviceSecurity/SpdmLib/libspdm/include/library",
+            # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
+            #                  submodule in the libspdm submodule is stable
+            #                  (on github)
         ],
         "skip": True
     },
@@ -148,9 +162,15 @@
             "loongson"
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
-        "IgnoreFiles": [
-          "DeviceSecurity/SpdmLib/libspdm"
-        ],
+        # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
+        #                    submodule in the libspdm submodule is stable
+        #                    (on github)
+        # "IgnoreFiles": [
+        #   "DeviceSecurity/SpdmLib/libspdm"
+        # ],
+        # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
+        #                  submodule in the libspdm submodule is stable
+        #                  (on github)
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
     },
 

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -25,7 +25,13 @@
 
 [Includes.Common.Private]
   DeviceSecurity/SpdmLib/Include
-  DeviceSecurity/SpdmLib/libspdm/include
+  # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
+  #                    submodule in the libspdm submodule is stable
+  #                    (on github)
+  # DeviceSecurity/SpdmLib/libspdm/include
+  # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
+  #                  submodule in the libspdm submodule is stable
+  #                  (on github)
 
 [LibraryClasses]
   ##  @libraryclass  Provides hash interfaces from different implementations.

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -78,18 +78,22 @@
   SecureBootVariableProvisionLib|SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
-  SpdmSecurityLib|SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
-  SpdmDeviceSecretLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
-  SpdmCryptLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
-  SpdmCommonLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
-  SpdmRequesterLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
-  SpdmResponderLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
-  SpdmSecuredMessageLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
-  SpdmTransportMctpLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
-  SpdmTransportPciDoeLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
-  CryptlibWrapper|SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
-  PlatformLibWrapper|SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
-  MemLibWrapper|SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
+  # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka submodule in the
+  #                    libspdm submodule is stable (on github)
+  # SpdmSecurityLib|SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
+  # SpdmDeviceSecretLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
+  # SpdmCryptLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
+  # SpdmCommonLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
+  # SpdmRequesterLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
+  # SpdmResponderLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
+  # SpdmSecuredMessageLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
+  # SpdmTransportMctpLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
+  # SpdmTransportPciDoeLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
+  # CryptlibWrapper|SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
+  # PlatformLibWrapper|SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
+  # MemLibWrapper|SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
+  # MU_CHANGE [END]: Remove SPDM from the build until the cmocka submodule in the
+  #                  libspdm submodule is stable (on github)
   OemTpm2InitLib|SecurityPkg/Library/OemTpm2InitLibNull/OemTpm2InitLib.inf               ## MS_CHANGE_?
   SourceDebugEnabledLib|SourceLevelDebugPkg/Library/SourceDebugEnabled/SourceDebugEnabledLib.inf ## MS_CHANGE_?
   Hash2CryptoLib|SecurityPkg/Library/BaseHash2CryptoLibNull/BaseHash2CryptoLibNull.inf   ## MU_CHANGE
@@ -314,18 +318,22 @@
   #
   # SPDM
   #
-  SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
-  SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
-  SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
-  SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
-  SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
+  # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka submodule in the
+  #                    libspdm submodule is stable (on github)
+  # SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
+  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
+  # SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
+  # SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
+  # SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
+  # MU_CHANGE [END]: Remove SPDM from the build until the cmocka submodule in the
+  #                  libspdm submodule is stable (on github)
 
 [Components.IA32, Components.X64]
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library==0.21.5
-edk2-pytool-extensions==0.27.4
+edk2-pytool-extensions==0.27.5
 antlr4-python3-runtime==4.13.1
 regex==2024.5.10
 lcov-cobertura==2.0.2


### PR DESCRIPTION
## Description

The `SecurityPkg/DeviceSecurity/SpdmLib/libspdm` submodule contains a
`unit_test/cmockalib/cmocka` submodule to https://git.cryptomilk.org/projects/cmocka.git.

cryptomilk.org is very unreliable and breaking all builds right now.
Since the DeviceSecurity content is not actively used in any main
branches, this change removes the `libspdm` submodule from the package
which, in turn, leads to removal of the content dependent on the
submodule.

**These changes are made such that this commit can be reverted in the future**.

That will easily restore everything after the `libspdm` submodule is updated
to find a more reliable host than cryptomilk.org.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- SecurityPkg CI build

## Integration Instructions

- This is a temporary change. It is expected to be reverted soon.
  - If you depend on the `libspdm` submodule in SecurityPkg, it is
    recommended to stay on the commit prior to its removal and wait
    for it to be restored in a future commit.
  - If you do not depend on the `libspdm` submodule, there is not impact.
- If you pick up this change be aware that any files in your build
  dependent on the `libspdm` submodule will fail.