### PR TITLE
Restore Device Security [Rebase & FF]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SecurityPkg/DeviceSecurity/SpdmLib/libspdm"]
+	path = SecurityPkg/DeviceSecurity/SpdmLib/libspdm
+	url = https://github.com/DMTF/libspdm.git

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -7,11 +7,5 @@
 # Ignore cloned dependencies
 /MU_BASECORE
 
-# MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
-#                    submodule in the libspdm submodule is stable
-#                    (on github)
 # Ignore libspdm submodule
-# /SecurityPkg/DeviceSecurity/SpdmLib/libspdm
-# MU_CHANGE [END]: Remove SPDM from the build until the cmocka
-#                  submodule in the libspdm submodule is stable
-#                  (on github)
+/SecurityPkg/DeviceSecurity/SpdmLib/libspdm

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -171,14 +171,8 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         If no RequiredSubmodules return an empty iterable
         '''
         rs = []
-        # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
-        #                    submodule in the libspdm submodule is stable
-        #                    (on github)
-        # rs.append(RequiredSubmodule(
-        #     "SecurityPkg/DeviceSecurity/SpdmLib/libspdm", False))
-        # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
-        #                  submodule in the libspdm submodule is stable
-        #                  (on github)
+        rs.append(RequiredSubmodule(
+            "SecurityPkg/DeviceSecurity/SpdmLib/libspdm", False))
         return rs
 
     def GetName(self):

--- a/SecurityPkg/SecurityPkg.ci.yaml
+++ b/SecurityPkg/SecurityPkg.ci.yaml
@@ -68,15 +68,7 @@
     },
     "DscCompleteCheck": {
         "DscPath": "SecurityPkg.dsc",
-        "IgnoreInf": [
-            # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
-            #                    submodule in the libspdm submodule is stable
-            #                    (on github)
-            SecurityPkg/DeviceSecurity/**
-            # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
-            #                  submodule in the libspdm submodule is stable
-            #                  (on github)
-        ]
+        "IgnoreInf": []
     },
     ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
     "HostUnitTestDscCompleteCheck": {
@@ -94,13 +86,7 @@
     "LibraryClassCheck": {
         "IgnoreHeaderFile": [
             "DeviceSecurity/SpdmLib/Include/library",
-            # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
-            #                    submodule in the libspdm submodule is stable
-            #                    (on github)
-            # "DeviceSecurity/SpdmLib/libspdm/include/library",
-            # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
-            #                  submodule in the libspdm submodule is stable
-            #                  (on github)
+            "DeviceSecurity/SpdmLib/libspdm/include/library",
         ],
         "skip": True
     },
@@ -162,15 +148,9 @@
             "loongson"
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
-        # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
-        #                    submodule in the libspdm submodule is stable
-        #                    (on github)
-        # "IgnoreFiles": [
-        #   "DeviceSecurity/SpdmLib/libspdm"
-        # ],
-        # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
-        #                  submodule in the libspdm submodule is stable
-        #                  (on github)
+        "IgnoreFiles": [
+          "DeviceSecurity/SpdmLib/libspdm"
+        ],
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
     },
 

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -25,13 +25,7 @@
 
 [Includes.Common.Private]
   DeviceSecurity/SpdmLib/Include
-  # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka
-  #                    submodule in the libspdm submodule is stable
-  #                    (on github)
-  # DeviceSecurity/SpdmLib/libspdm/include
-  # MU_CHANGE [END]: Remove SPDM from the build until the cmocka
-  #                  submodule in the libspdm submodule is stable
-  #                  (on github)
+  DeviceSecurity/SpdmLib/libspdm/include
 
 [LibraryClasses]
   ##  @libraryclass  Provides hash interfaces from different implementations.

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -78,22 +78,18 @@
   SecureBootVariableProvisionLib|SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.inf
   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
-  # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka submodule in the
-  #                    libspdm submodule is stable (on github)
-  # SpdmSecurityLib|SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
-  # SpdmDeviceSecretLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
-  # SpdmCryptLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
-  # SpdmCommonLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
-  # SpdmRequesterLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
-  # SpdmResponderLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
-  # SpdmSecuredMessageLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
-  # SpdmTransportMctpLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
-  # SpdmTransportPciDoeLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
-  # CryptlibWrapper|SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
-  # PlatformLibWrapper|SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
-  # MemLibWrapper|SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
-  # MU_CHANGE [END]: Remove SPDM from the build until the cmocka submodule in the
-  #                  libspdm submodule is stable (on github)
+  SpdmSecurityLib|SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
+  SpdmDeviceSecretLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
+  SpdmCryptLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
+  SpdmCommonLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
+  SpdmRequesterLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
+  SpdmResponderLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
+  SpdmSecuredMessageLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
+  SpdmTransportMctpLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
+  SpdmTransportPciDoeLib|SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
+  CryptlibWrapper|SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
+  PlatformLibWrapper|SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
+  MemLibWrapper|SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
   OemTpm2InitLib|SecurityPkg/Library/OemTpm2InitLibNull/OemTpm2InitLib.inf               ## MS_CHANGE_?
   SourceDebugEnabledLib|SourceLevelDebugPkg/Library/SourceDebugEnabled/SourceDebugEnabledLib.inf ## MS_CHANGE_?
   Hash2CryptoLib|SecurityPkg/Library/BaseHash2CryptoLibNull/BaseHash2CryptoLibNull.inf   ## MU_CHANGE
@@ -318,22 +314,18 @@
   #
   # SPDM
   #
-  # MU_CHANGE [BEGIN]: Remove SPDM from the build until the cmocka submodule in the
-  #                    libspdm submodule is stable (on github)
-  # SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
-  # SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
-  # SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
-  # SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
-  # SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
-  # MU_CHANGE [END]: Remove SPDM from the build until the cmocka submodule in the
-  #                  libspdm submodule is stable (on github)
+  SecurityPkg/DeviceSecurity/SpdmSecurityLib/SpdmSecurityLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmDeviceSecretLibNull.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmCryptLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmCommonLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmRequesterLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmResponderLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmSecuredMessageLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportMctpLib.inf
+  SecurityPkg/DeviceSecurity/SpdmLib/SpdmTransportPciDoeLib.inf
+  SecurityPkg/DeviceSecurity/OsStub/CryptlibWrapper/CryptlibWrapper.inf
+  SecurityPkg/DeviceSecurity/OsStub/PlatformLibWrapper/PlatformLibWrapper.inf
+  SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
 
 [Components.IA32, Components.X64]
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf


### PR DESCRIPTION
## Description

Resolves #275 

---

**CHANGE 1**:

**SecurityPkg: Restore DeviceSecurity (and libspdm submodule)**

Reverts the following commit:

"SecurityPkg: Temporarily remove DeviceSecurity (and libspdm) from build"
(11506d59b72515a8d561baddfa2bb6660924ad6e)

The libspdm submodule is updated in the following commit to use a
cmocka from a more reliable host (GitLab). This revert is necessary
for that cherry-pick from edk2 to apply.

---

**CHANGE 2**:

**[CHERRY-PICK] SecurityPkg: Update libspdm submodule to use GitLab cmocka repo**

As noted in https://github.com/DMTF/libspdm/issues/2707, the cmocka
submodule on cryptomilk is unreliable and impacting downstream
consumer builds of SecurityPkg. This is considered a regression in
that pre-existing workflows that clone and recursively initialize
the repo are now broken.

The cmocka host was switched to a more reliable gitlab host in
https://github.com/DMTF/libspdm/pull/2710. This change updates the
submodule in edk2 to use that commit so edk2 users are not blocked
by cryptomilk.org service issues.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- SecurityPkg CI build

## Integration Instructions

- First, note that this PR reverts PR https://github.com/microsoft/mu_tiano_plus/pull/272.
  - Review any changes you may have made in response to that PR.
- This PR adds the DeviceSecurity code back to the SecurityPkg build. That should not impact downstream users as the code was not removed, only not built in SecurityPkg.
- The libspdm submodule is added back. That submodule will now be present for downstream repos (and SecurityPkg code) to use.