### PR TITLE
EmbeddedPkg: Enable build under VS2019 and fix build errors.

### DIFF
--- a/EmbeddedPkg/Library/GdbSerialDebugPortLib/GdbSerialDebugPortLib.c
+++ b/EmbeddedPkg/Library/GdbSerialDebugPortLib/GdbSerialDebugPortLib.c
@@ -17,7 +17,8 @@
 #include <Protocol/DebugPort.h>
 
 EFI_DEBUGPORT_PROTOCOL  *gDebugPort = NULL;
-UINT32                  gTimeOut    = 0;
+// UINTN                   gTimeOut = 0;  // MU_CHANGE TCBZ3616
+UINT32  gTimeOut = 0;                     // MU_CHANGE TCBZ3616
 
 /**
   The constructor function initializes the UART.


### PR DESCRIPTION
## Description

Turn off modules in EmbeddedPkg's that cannot be compiled under VS.
Fix multiple 64 to 32 bit conversions.


8fa524eddf
6d66d4a64e (already included in #287)

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Local CI.

## Integration Instructions
N/A