### PR TITLE
[Rebase & FF] 202405: Renaming shell test app in FmpDevicePkg

### DIFF
--- a/FmpDevicePkg/FmpDevicePkg.dsc
+++ b/FmpDevicePkg/FmpDevicePkg.dsc
@@ -174,7 +174,7 @@
   #
   # Add UEFI Target Based Unit Tests
   #
-  FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestsUefi.inf
+  FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
 
 [BuildOptions]
   *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES

--- a/FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
+++ b/FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
@@ -7,7 +7,7 @@
 
 [Defines]
   INF_VERSION                    = 0x00010006
-  BASE_NAME                      = FmpDependencyLibUnitTestsUefi
+  BASE_NAME                      = FmpDependencyLibUnitTestApp
   FILE_GUID                      = 8FF4C129-C2EF-445D-8658-9A342A1FCC4D
   MODULE_TYPE                    = UEFI_APPLICATION
   VERSION_STRING                 = 1.0


### PR DESCRIPTION
## Description
Renaming shell test app in FmpDevicePkg

---
Cherry picked the following commit:

974b5f148f

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Changes from release/202311

## Integration Instructions

Upgrading from 202311 to 202405 -> No change for platform

Upgrading from edk2 -> 202405, change the path (if it exists) as follows:

`FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestsUefi.inf`
  `FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf`