### PR TITLE
[Rebase& FF] 202405: SecurityPkg/Tcg2Smm: Added communicate buffer check

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -73,7 +73,7 @@ TpmNvsCommunciate (
     return EFI_ACCESS_DENIED;
   }
 
-  if (!IsBufferOutsideMmValid ((UINTN)CommBuffer, TempCommBufferSize)) {
+  if (!IsCommBufferValid ((UINTN)CommBuffer, TempCommBufferSize)) {
     DEBUG ((DEBUG_ERROR, "[%a] - MM Communication buffer in invalid location!\n", __func__));
     return EFI_ACCESS_DENIED;
   }

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.h
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.h
@@ -70,6 +70,22 @@ IsBufferOutsideMmValid (
   );
 
 /**
+  This function is wrapper function to validate the communicate buffer.
+
+  @param Buffer  The buffer start address to be checked.
+  @param Length  The buffer length to be checked.
+
+  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
+  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
+**/
+BOOLEAN
+EFIAPI
+IsCommBufferValid (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINT64                Length
+  );
+
+/**
   The driver's common initialization routine.
 
   It install callbacks for TPM physical presence and MemoryClear, and locate

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.c
@@ -48,6 +48,25 @@ IsBufferOutsideMmValid (
 }
 
 /**
+  This function is wrapper function to validate the communicate buffer.
+
+  @param Buffer  The buffer start address to be checked.
+  @param Length  The buffer length to be checked.
+
+  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
+  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
+**/
+BOOLEAN
+EFIAPI
+IsCommBufferValid (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINT64                Length
+  )
+{
+  return MmCommBufferValid (Buffer, Length);
+}
+
+/**
   The driver's entry point.
 
   It install callbacks for TPM physical presence and MemoryClear, and locate

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2TraditionalMm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2TraditionalMm.c
@@ -59,6 +59,25 @@ IsBufferOutsideMmValid (
 }
 
 /**
+  This function is wrapper function to validate the communicate buffer.
+
+  @param Buffer  The buffer start address to be checked.
+  @param Length  The buffer length to be checked.
+
+  @retval TRUE  This buffer is valid per processor architecture and not overlap with SMRAM.
+  @retval FALSE This buffer is not valid per processor architecture or overlap with SMRAM.
+**/
+BOOLEAN
+EFIAPI
+IsCommBufferValid (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINT64                Length
+  )
+{
+  return SmmIsBufferOutsideSmmValid (Buffer, Length);
+}
+
+/**
   The driver's entry point.
 
   It install callbacks for TPM physical presence and MemoryClear, and locate


### PR DESCRIPTION
## Description

Added communicate buffer check for the Tcg2Smm driver in lieu of the legacy MmOutsideValid check.

---

Cherry-picked commit:

4d4080f099

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Changes from release/202311

## Integration Instructions

N/A