### PR TITLE
[REBASE & FF] Update Memory Attribute Updating Code to Set Attributes Correctly

### DIFF
--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
@@ -557,7 +557,7 @@ DmaAllocateAlignedBuffer (
   Status = gDS->SetMemorySpaceAttributes (
                   (PHYSICAL_ADDRESS)(UINTN)Allocation,
                   EFI_PAGES_TO_SIZE (Pages),
-                  MemType
+                  MemType | EFI_MEMORY_XP // MU_CHANGE: Allocate DMA memory XP by default
                   );
   if (EFI_ERROR (Status)) {
     goto FreeAlloc;

--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -155,7 +155,14 @@ SetRuntimeMemoryRangeAttributes (
     Status = gDS->SetMemorySpaceAttributes (
                     RuntimeMmioRanges->Range[Index].PhysicalBaseAddress,
                     (UINT64)RuntimeMmioRanges->Range[Index].Length,
-                    Descriptor.Attributes | EFI_MEMORY_RUNTIME
+                    // MU_CHANGE START: The memory space descriptor access attributes are not accurate. Don't pass
+                    //                  in access attributes so SetMemorySpaceAttributes() doesn't update them.
+                    //                  EFI_MEMORY_RUNTIME is not a CPU arch attribute, so calling
+                    //                  SetMemorySpaceAttributes() with only it set will not clear existing page table
+                    //                  attributes for this region, such as EFI_MEMORY_XP
+                    // Descriptor.Attributes | EFI_MEMORY_RUNTIME
+                    EFI_MEMORY_RUNTIME
+                    // MU_CHANGE END
                     );
     ASSERT_EFI_ERROR (Status);
     if (EFI_ERROR (Status)) {


### PR DESCRIPTION
## Description

This PR addresses two issues with code passing in access attributes to SetMemorySpaceAttributes() that cause the existing attributes to be overwritten. The GCD descriptor is not kept in sync with the page table and as such we trust the memory protection code to properly protect regions. External driver code should either not update access attributes (as with the PRM Runtime update) or use the correct attributes (such as marking DMA memory as XP, in the second commit).

Cherry-picking d3d29f2f5e and 1435e7c892.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A