### PR TITLE
[CHERRY-PICK] SecurityPkg: Remove a debug statement that may cause a machine check.

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
@@ -639,7 +639,7 @@ UpdateHID (
         CopyMem (DataPtr, Hid, TPM_HID_ACPI_SIZE);
       }
 
-      DEBUG ((DEBUG_INFO, "TPM2 ACPI _HID is patched to %a\n", DataPtr));
+      DEBUG ((DEBUG_INFO, "TPM2 ACPI _HID is patched to %a\n", Hid));
 
       return Status;
     }


### PR DESCRIPTION
## Description

There is a debug print in Tcg2Acpi.c that attempts to print a string that has had the null terminator removed. The attempted print can cause a page fault.

This was cherry-picking 5397c095ac from release/202311, but was upstreamed to edk2 while this was in PR form and that commit was changed based on maintainer feedback, so now cherry-picking from edk2 commit: https://github.com/tianocore/edk2/commit/d4dbe5e101dcb86974f8dce3505b38343b83b432.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
