### PR TITLE
SecurityPkg: Remove Support for _DSM Memory Clear

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Acpi/Tpm.asl
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tpm.asl
@@ -240,6 +240,7 @@ DefinitionBlock (
 
       Method (PTS, 1, Serialized)
       {
+        #if 0 // MU_CHANGE Begin - Remove MOR auto-detect from TPM.PTS
         //
         // Detect Sx state for MOR, only S4, S5 need to handle
         //
@@ -261,6 +262,7 @@ DefinitionBlock (
             Store (MCIN, IOPN)
           }
         }
+        #endif // MU_CHANGE End
         Return (0)
       }
 
@@ -446,6 +448,7 @@ DefinitionBlock (
         Return (1)
       }
 
+      #if 0 // MU_CHANGE Begin - Remove support for _DSM Memory Clear
       Method (TMCI, 2, Serialized, 0, IntObj, {UnknownObj, UnknownObj}) // IntObj, PkgObj
       {
         //
@@ -482,6 +485,7 @@ DefinitionBlock (
         }
         Return (1)
       }
+      #endif // MU_CHANGE End
 
       Method (_DSM, 4, Serialized, 0, UnknownObj, {BuffObj, IntObj, IntObj, PkgObj})
       {
@@ -502,6 +506,8 @@ DefinitionBlock (
           Return (TPPI (Arg2, Arg3))
         }
 
+        // MU_CHANGE Begin - Remove support for _DSM memory clear
+        /*
         //
         // TCG Memory Clear Interface
         //
@@ -509,6 +515,8 @@ DefinitionBlock (
         {
           Return (TMCI (Arg2, Arg3))
         }
+        */
+        // MU_CHANGE End
 
         Return (Buffer () {0})
       }

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -158,6 +158,8 @@ PhysicalPresenceCallback (
   return EFI_SUCCESS;
 }
 
+#if 0 // MU_CHANGE Begin - MemoryClear SMI handler not used
+
 /**
   Software SMI callback for MemoryClear which is called from ACPI method.
 
@@ -232,6 +234,8 @@ MemoryClearCallback (
 
   return EFI_SUCCESS;
 }
+
+#endif // MU_CHANGE Begin - MemoryClear SMI handler not used
 
 /**
   Notification for SMM ReadyToLock protocol.
@@ -325,6 +329,7 @@ InitializeTcgCommon (
 
   mPpSoftwareSmi = SwContext.SwSmiInputValue;
 
+ #if 0  // MU_CHANGE Begin - MemoryClear SMI handler is not used
   SwContext.SwSmiInputValue = (UINTN)-1;
   Status                    = SwDispatch->Register (SwDispatch, MemoryClearCallback, &SwContext, &McSwHandle);
   ASSERT_EFI_ERROR (Status);
@@ -334,6 +339,7 @@ InitializeTcgCommon (
   }
 
   mMcSoftwareSmi = SwContext.SwSmiInputValue;
+ #endif // MU_CHANGE End
 
   //
   // Locate SmmVariableProtocol.


### PR DESCRIPTION
## Description

_DSM Memory Clear is not used, so this code removes it.

Cherry-picked from f911628cc9.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.