### PR TITLE
SecurityPkg: Measure Invoke EBS even in failure case

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -2615,6 +2615,20 @@ OnExitBootServicesFailed (
 {
   EFI_STATUS  Status;
 
+  // MU_CHANGE START: TCBZ2753
+  //
+  // Measure invocation of ExitBootServices,
+  //
+  Status = TcgMeasureAction (
+             5,
+             EFI_EXIT_BOOT_SERVICES_INVOCATION
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
+  }
+
+  // MU_CHANGE END TCBZ2753
+
   //
   // Measure Failure of ExitBootServices,
   //


### PR DESCRIPTION
## Description

This patch measures the ExitBootServices invocation to the TPM even in the case of ExitBootServices failing, so that we can keep a record of the failures and know what is expected.

Cherry-picked from ee71b24a93.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.