### PR TITLE
EmbeddedPkg: Initialize variables in FwVol.c (PrePiLib) for ARM64

### DIFF
--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -296,13 +296,15 @@ FfsProcessSection (
   UINT32                    CompressedDataLength;
   BOOLEAN                   Found;
 
-  Found = FALSE;
-
+  // MU_CHANGE Start: Initialize Variables
+  Found             = FALSE;
   *OutputBuffer     = NULL;
   ParsedLength      = 0;
   Status            = EFI_NOT_FOUND;
-  ScratchBufferSize = 0;    // MU_CHANGE
-  DstBufferSize     = 0;    // MU_CHANGE
+  ScratchBufferSize = 0;
+  DstBufferSize     = 0;
+  // MU_CHANGE End: Initialize Variables
+
   while (ParsedLength < SectionSize) {
     if (IS_SECTION2 (Section)) {
       ASSERT (SECTION2_SIZE (Section) > 0x00FFFFFF);


### PR DESCRIPTION
## Description

REF: TCBZ2820

This patch initializes variables that MSVC's ARM64 cross compiler complains about.

Cherry-picks df22fd89ed.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
