### PR TITLE
2405 Plugin Fixes [Rebase & FF]

### DIFF
--- a/FatPkg/FatPkg.ci.yaml
+++ b/FatPkg/FatPkg.ci.yaml
@@ -66,7 +66,10 @@
             "CDVOL",
             "DMDEPKG",
             "loongarch",
-            "loongson"
+            # MU_CHANGE - Start
+            "loongson",
+            "fstack"
+            # MU_CHANGE - End
         ]
     }
 }

--- a/FmpDevicePkg/FmpDevicePkg.ci.yaml
+++ b/FmpDevicePkg/FmpDevicePkg.ci.yaml
@@ -64,7 +64,10 @@
         "ExtendWords": [
             "FMPSTATE",
             "loongarch",
-            "loongson"
+            # MU_CHANGE - Start
+            "loongson",
+            "fstack"
+            # MU_CHANGE - End
         ]
     },
     "Defines": {

--- a/FmpDevicePkg/FmpDxe/ReadMe.md
+++ b/FmpDevicePkg/FmpDxe/ReadMe.md
@@ -54,8 +54,9 @@ More information about the overall infrastructure is available in:
 [Tianocore wiki: Fmp Capsule Dependency Introduction](https://github.com/tianocore/tianocore.github.io/wiki/Fmp-Capsule-Dependency-Introduction)
 
 More details regarding the libraries in `FmpDevicePkg` are available in the respective ReadMe files:
-[FmpDevicePkg/Library/FmpDependencyCheckLib][FmpDevicePkg/Library/FmpDependencyCheckLib/ReadMe.md](../Library/FmpDependencyCheckLib/ReadMe.md)
-[FmpDevicePkg/Library/FmpDependencyLib][FmpDevicePkg/Library/FmpDependencyLib/ReadMe.md](../Library/FmpDependencyLib/ReadMe.md)
+
+- [FmpDevicePkg/Library/FmpDependencyCheckLib](../Library/FmpDependencyCheckLib/ReadMe.md)
+- [FmpDevicePkg/Library/FmpDependencyLib](../Library/FmpDependencyLib/ReadMe.md)
 
 ### Update Policy
 

--- a/PrmPkg/PrmPkg.ci.yaml
+++ b/PrmPkg/PrmPkg.ci.yaml
@@ -104,7 +104,16 @@
           "prmopreg",
           "prmpecofflib",
           "prmpkg",
-          "prmssdtinstall"
+          # MU_CHANGE - Start
+          "prmssdtinstall",
+          "fstack",
+          "dlink",
+          "prmconfig",
+          "prmcontextbufferlib",
+          "prminfo",
+          "prmloader",
+          "prmmodulediscoverylib"
+          # MU_CHANGE - End
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that
                                      # should be ignore

--- a/PrmPkg/Samples/Readme.md
+++ b/PrmPkg/Samples/Readme.md
@@ -44,7 +44,7 @@ and interact with their PRM modules.
 
 >* Name: `PrmSampleAcpiParameterBufferModule`
 >* GUID: `dc2a58a6-5927-4776-b995-d118a27335a2`
-> * Purpose:
+>* Purpose:
 >   * Provides an example of how to configure an ACPI parameter buffer
 
 **Handlers:**
@@ -68,7 +68,7 @@ and interact with their PRM modules.
 
 >* Name: `PrmSampleContextBufferModule`
 >* GUID: `5a6cf42b-8bb4-472c-a233-5c4dc4033dc7`
-> * Purpose:
+>* Purpose:
 >   * Provides an example of how to configure a static data buffer (which is pointed to in a context buffer) in
       firmware and consume the buffer contents at runtime
 
@@ -102,7 +102,7 @@ and interact with their PRM modules.
 
 >* Name: `PrmSampleHardwareAccessModule`
 >* GUID: `0ef93ed7-14ae-425b-928f-b85a6213b57e`
-> * Purpose:
+>* Purpose:
 >   * Demonstrate access of several types of hardware resources from a PRM module
 
 **Handlers:**


### PR DESCRIPTION
## Description

2405 introduced errors in SpellCheck and markdownlint not found
until plugins were added in Mu Basecore.

This fixes them so CI will resume.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local CI build using NO-TARGET.

## Integration Instructions

N/A