### PR TITLE
[Rebase & FF] 202405: PK Changes for Secure Boot

### DIFF
--- a/FmpDevicePkg/FmpDevicePkg.dec
+++ b/FmpDevicePkg/FmpDevicePkg.dec
@@ -84,6 +84,18 @@
   # @Prompt SHA-256 hash of PKCS7 test key.
   gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceTestKeySha256Digest|{0x2E, 0x97, 0x89, 0x1B, 0xDB, 0xE7, 0x08, 0xAA,  0x8C, 0xB2, 0x8F, 0xAD, 0x20, 0xA9, 0x83, 0xC7,  0x84, 0x7D, 0x4F, 0xEE, 0x48, 0x25, 0xE9, 0x4D,  0x39, 0xFA, 0x34, 0x9A, 0xB8, 0xB1, 0xC4, 0x26}|VOID*|0x40000009
 
+  ## MU_CHANGE [BEGIN] - Added Pkcs7 EKU value
+  ## This PCD controls the Enhanced Key Usage (EKU) that must be present in the leaf
+  ## signer certificate in order to unlock a device.  The default value is 0, which
+  ## means "do not require an EKU" in the signature to unlock the device for backwards
+  ## compatibility.  Then if the product specific DSC file over-rides this value,
+  ## then the verification code will require that the specified EKU is present in the
+  ## leaf signer.  This allows us to cut down on the number of Certificate Authorities
+  ## (CA's) required, and prevents one product from unlocking another one.
+  ## Setting it to zero or not overriding will skip the check
+  gFmpDevicePkgTokenSpaceGuid.PcdFmpDxeRequiredEKU|"0"|VOID*|0x40000013
+  ## MU_CHANGE [END] - Added Pkcs7 EKU Value
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## The color of the progress bar during a firmware update.  Each firmware
   #  device can set its own color.  The default color is white.<BR><BR>

--- a/FmpDevicePkg/FmpDxe/FmpDxe.inf
+++ b/FmpDevicePkg/FmpDxe/FmpDxe.inf
@@ -76,6 +76,7 @@
   gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceTestKeySha256Digest              ## CONSUMES
   gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceImageTypeIdGuid                  ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTestKeyUsed                            ## SOMETIMES_PRODUCES
+  gFmpDevicePkgTokenSpaceGuid.PcdFmpDxeRequiredEKU                         ## CONSUMES  ## MU_CHANGE
 
 [Depex]
   gEfiVariableWriteArchProtocolGuid AND gEdkiiVariableLockProtocolGuid

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -716,10 +716,13 @@ ProcessVarWithPk (
   // Init state of Del. State may change due to secure check
   //
   Del = FALSE;
-  if (  (InCustomMode () && UserPhysicalPresent ())
+  // MU_CHANGE [START] SecurityPkg/Secureboot: Support Fix delete PK failing bug
+  if (  ((InCustomMode () && UserPhysicalPresent ()) || (!IsVariablePolicyEnabled ()))
      || (  (mPlatformMode == SETUP_MODE)
         && !(FeaturePcdGet (PcdRequireSelfSignedPk) && IsPk)))
   {
+    // MU_CHANGE [END] SecurityPkg/Secureboot: Support Fix delete PK failing bug
+
     Payload     = (UINT8 *)Data + AUTHINFO2_SIZE (Data);
     PayloadSize = DataSize - AUTHINFO2_SIZE (Data);
     if (PayloadSize == 0) {

--- a/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
+++ b/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
@@ -44,6 +44,11 @@
   PlatformSecureLib
   VariablePolicyLib
 
+# MU_CHANGE [BEGIN] - TCBZ2506
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEnforceSelfsignedPk
+# MU_CHANGE [END]
+
 [Guids]
   ## CONSUMES            ## Variable:L"SetupMode"
   ## PRODUCES            ## Variable:L"SetupMode"

--- a/SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf
+++ b/SecurityPkg/Library/FmpAuthenticationLibPkcs7/FmpAuthenticationLibPkcs7.inf
@@ -31,6 +31,7 @@
   MdeModulePkg/MdeModulePkg.dec
   SecurityPkg/SecurityPkg.dec
   CryptoPkg/CryptoPkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec ## MU_CHANGE
 
 [LibraryClasses]
   BaseLib
@@ -38,6 +39,9 @@
   DebugLib
   MemoryAllocationLib
   BaseCryptLib
+
+[Pcd]
+  gFmpDevicePkgTokenSpaceGuid.PcdFmpDxeRequiredEKU  ## CONSUMES ## MU_CHANGE
 
 [Guids]
   gEfiCertPkcs7Guid        ## CONSUMES   ## GUID

--- a/SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.c
@@ -577,10 +577,12 @@ DeletePlatformKey (
 {
   EFI_STATUS  Status;
 
-  Status = SetSecureBootMode (CUSTOM_SECURE_BOOT_MODE);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+  // MU_CHANGE [BEGIN] - Remove the indicator of custom secure boot mode variable
+  // Status = SetSecureBootMode (CUSTOM_SECURE_BOOT_MODE);
+  // if (EFI_ERROR (Status)) {
+  //   return Status;
+  // }
+  // MU_CHANGE [END]
 
   Status = DeleteVariable (
              EFI_PLATFORM_KEY_NAME,

--- a/SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.c
@@ -835,15 +835,18 @@ DeletePKShouldDelete (
   UINT8       Dummy       = 3;
   UINT8       *Payload    = NULL;
   UINTN       PayloadSize = 0;
-  UINT8       BootMode    = CUSTOM_SECURE_BOOT_MODE;
 
-  expect_memory (MockSetVariable, VariableName, EFI_CUSTOM_MODE_NAME, sizeof (EFI_CUSTOM_MODE_NAME));
-  expect_value (MockSetVariable, VendorGuid, &gEfiCustomModeEnableGuid);
-  expect_value (MockSetVariable, Attributes, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS);
-  expect_value (MockSetVariable, DataSize, sizeof (BootMode));
-  expect_memory (MockSetVariable, Data, &BootMode, sizeof (BootMode));
+  // MU_CHANGE [BEGIN] - Remove the indicator of custom secure boot mode variable
+  // UINT8       BootMode    = CUSTOM_SECURE_BOOT_MODE;
 
-  will_return (MockSetVariable, EFI_SUCCESS);
+  // expect_memory (MockSetVariable, VariableName, EFI_CUSTOM_MODE_NAME, sizeof (EFI_CUSTOM_MODE_NAME));
+  // expect_value (MockSetVariable, VendorGuid, &gEfiCustomModeEnableGuid);
+  // expect_value (MockSetVariable, Attributes, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS);
+  // expect_value (MockSetVariable, DataSize, sizeof (BootMode));
+  // expect_memory (MockSetVariable, Data, &BootMode, sizeof (BootMode));
+
+  // will_return (MockSetVariable, EFI_SUCCESS);
+  // MU_CHANGE [END]
 
   expect_memory (MockGetVariable, VariableName, EFI_PLATFORM_KEY_NAME, sizeof (EFI_PLATFORM_KEY_NAME));
   expect_value (MockGetVariable, VendorGuid, &gEfiGlobalVariableGuid);
@@ -903,7 +906,8 @@ DeleteSecureBootVariablesShouldDelete (
   UINT8       Dummy       = 3;
   UINT8       *Payload    = NULL;
   UINTN       PayloadSize = 0;
-  UINT8       BootMode    = CUSTOM_SECURE_BOOT_MODE;
+
+  // UINT8       BootMode    = CUSTOM_SECURE_BOOT_MODE; // MU_CHANGE
 
   Status = CreateTimeBasedPayload (&PayloadSize, &Payload, &mMaxTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
@@ -911,13 +915,15 @@ DeleteSecureBootVariablesShouldDelete (
 
   will_return (DisablePKProtection, EFI_SUCCESS);
 
-  expect_memory (MockSetVariable, VariableName, EFI_CUSTOM_MODE_NAME, sizeof (EFI_CUSTOM_MODE_NAME));
-  expect_value (MockSetVariable, VendorGuid, &gEfiCustomModeEnableGuid);
-  expect_value (MockSetVariable, Attributes, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS);
-  expect_value (MockSetVariable, DataSize, sizeof (BootMode));
-  expect_memory (MockSetVariable, Data, &BootMode, sizeof (BootMode));
+  // MU_CHANGE [BEGIN] - Remove the indicator of custom secure boot mode variable
+  // expect_memory (MockSetVariable, VariableName, EFI_CUSTOM_MODE_NAME, sizeof (EFI_CUSTOM_MODE_NAME));
+  // expect_value (MockSetVariable, VendorGuid, &gEfiCustomModeEnableGuid);
+  // expect_value (MockSetVariable, Attributes, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS);
+  // expect_value (MockSetVariable, DataSize, sizeof (BootMode));
+  // expect_memory (MockSetVariable, Data, &BootMode, sizeof (BootMode));
 
-  will_return (MockSetVariable, EFI_SUCCESS);
+  // will_return (MockSetVariable, EFI_SUCCESS);
+  // MU_CHANGE [END]
 
   expect_memory (MockGetVariable, VariableName, EFI_PLATFORM_KEY_NAME, sizeof (EFI_PLATFORM_KEY_NAME));
   expect_value (MockGetVariable, VendorGuid, &gEfiGlobalVariableGuid);
@@ -1093,17 +1099,20 @@ DeleteSecureBootVariablesShouldProceedWithNotFound (
   )
 {
   EFI_STATUS  Status;
-  UINT8       BootMode = CUSTOM_SECURE_BOOT_MODE;
+
+  // UINT8       BootMode = CUSTOM_SECURE_BOOT_MODE;  // MU_CHANGE
 
   will_return (DisablePKProtection, EFI_SUCCESS);
 
-  expect_memory (MockSetVariable, VariableName, EFI_CUSTOM_MODE_NAME, sizeof (EFI_CUSTOM_MODE_NAME));
-  expect_value (MockSetVariable, VendorGuid, &gEfiCustomModeEnableGuid);
-  expect_value (MockSetVariable, Attributes, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS);
-  expect_value (MockSetVariable, DataSize, sizeof (BootMode));
-  expect_memory (MockSetVariable, Data, &BootMode, sizeof (BootMode));
+  // MU_CHANGE [BEGIN] - Remove the indicator of custom secure boot mode variable
+  // expect_memory (MockSetVariable, VariableName, EFI_CUSTOM_MODE_NAME, sizeof (EFI_CUSTOM_MODE_NAME));
+  // expect_value (MockSetVariable, VendorGuid, &gEfiCustomModeEnableGuid);
+  // expect_value (MockSetVariable, Attributes, EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS);
+  // expect_value (MockSetVariable, DataSize, sizeof (BootMode));
+  // expect_memory (MockSetVariable, Data, &BootMode, sizeof (BootMode));
 
-  will_return (MockSetVariable, EFI_SUCCESS);
+  // will_return (MockSetVariable, EFI_SUCCESS);
+  // MU_CHANGE [END]
 
   expect_memory (MockGetVariable, VariableName, EFI_PLATFORM_KEY_NAME, sizeof (EFI_PLATFORM_KEY_NAME));
   expect_value (MockGetVariable, VendorGuid, &gEfiGlobalVariableGuid);

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -95,6 +95,16 @@
   #
   TcgStorageOpalLib|Include/Library/TcgStorageOpalLib.h
 
+  ## MU_CHANGE [BEGIN]
+  ## @libraryclass  Provides interfaces to access RPMC device.
+  #
+  RpmcLib|Include/Library/RpmcLib.h
+
+  ## @libraryclass  Provides interfaces to access variable root key.
+  #
+  VariableKeyLib|Include/Library/VariableKeyLib.h
+  ## MU_CHANGE [END]
+
   ## @libraryclass  Provides interfaces about firmware TPM measurement.
   #
   TcgEventLogRecordLib|Include/Library/TcgEventLogRecordLib.h
@@ -647,6 +657,14 @@
   #   FALSE - Do not require PK to be self-signed.
   # @Prompt Require PK to be self-signed
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireSelfSignedPk|FALSE|BOOLEAN|0x00010027
+
+# MU_CHANGE [BEGIN] - TCBZ2506
+  ## Indicates if the platform will enforce PK's to be self signed when setting the PK with none currently set
+  #   TRUE  - Require PK to be self signed
+  #   FALSE - Does not require PK to be self signed
+  # @Prompt Enforce PK to be self signed
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEnforceSelfsignedPk|FALSE|BOOLEAN|0x00010024
+# MU_CHANGE [END]
 
 [UserExtensions.TianoCore."ExtraFiles"]
   SecurityPkgExtra.uni


### PR DESCRIPTION
## Description

Cherry picked the following commits:

f56c7156f6
16201575d8
869f5134e0 - moved earlier
503fd7b069
36b848b39c - dropped
f61757573c - dropped
ef83307ad8 - dropped
c15f0af

---

- [x] Impacts functionality?
Allows for a PK to be deleted
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Changes from release/202311

## Integration Instructions

N/A