### PR TITLE
Require cspell 5.20.0 and apply fixes to all relevant files

### DIFF
--- a/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
+++ b/EmbeddedPkg/Drivers/AndroidFastbootTransportTcpDxe/FastbootTransportTcp.c
@@ -87,7 +87,7 @@ DataReceived (
 */
 STATIC
 EFI_STATUS
-SubmitRecieveToken (
+SubmitReceiveToken (
   VOID
   )
 {
@@ -208,7 +208,7 @@ DataReceived (
       = ReceiveToken->Packet.RxData->FragmentTable[0].FragmentLength;
 
     // Prepare to receive more data
-    SubmitRecieveToken ();
+    SubmitReceiveToken ();
   } else {
     // Fatal receive error. Put an entry with NULL in the queue, signifying
     // to return EFI_DEVICE_ERROR from TcpFastbootTransportReceive.
@@ -282,7 +282,7 @@ ConnectionAccepted (
   }
 
   for (Index = 0; Index < NUM_RX_TOKENS; Index++) {
-    SubmitRecieveToken ();
+    SubmitReceiveToken ();
   }
 }
 

--- a/EmbeddedPkg/Drivers/VirtualKeyboardDxe/VirtualKeyboard.c
+++ b/EmbeddedPkg/Drivers/VirtualKeyboardDxe/VirtualKeyboard.c
@@ -29,7 +29,7 @@ EFI_DRIVER_BINDING_PROTOCOL  gVirtualKeyboardDriverBinding = {
 /**
   Check whether the driver supports this device.
 
-  @param  This                   The Udriver binding protocol.
+  @param  This                   The driver binding protocol.
   @param  Controller             The controller handle to check.
   @param  RemainingDevicePath    The remaining device path.
 
@@ -500,7 +500,7 @@ VirtualKeyboardWaitForKey (
   // will have a bad performance during this period,
   // e.g. usb keyboard driver.
   // Add a stall period can greatly increate other driver performance during
-  // the WaitForKey is recursivly invoked. 1ms delay will make little impact
+  // the WaitForKey is recursively invoked. 1ms delay will make little impact
   // to the thunk keyboard driver, and user can not feel the delay at all when
   // input.
   //
@@ -666,7 +666,7 @@ KeyboardReadKeyStrokeWorker (
   // bad performance during this period,
   // e.g. usb keyboard driver.
   // Add a stall period can greatly increate other driver performance during
-  // the WaitForKey is recursivly invoked. 1ms delay will make little impact
+  // the WaitForKey is recursively invoked. 1ms delay will make little impact
   // to the thunk keyboard driver, and user can not feel the delay at all when
   // input.
   //

--- a/EmbeddedPkg/EmbeddedPkg.dec
+++ b/EmbeddedPkg/EmbeddedPkg.dec
@@ -151,7 +151,7 @@
   # Android FastBoot
   #
 
-  # The Android FastBoot utility has hard-coded USB Vendor IDs that it recognises
+  # The Android FastBoot utility has hard-coded USB Vendor IDs that it can recognise
   # (and 0xf00d isn't one of them!).
   # You'll need to pass it "-i 0xf00d" to get it to recognise this device.
   gEmbeddedTokenSpaceGuid.PcdAndroidFastbootUsbVendorId|0xf00d|UINT32|0x00000022

--- a/EmbeddedPkg/GdbStub/SerialIo.c
+++ b/EmbeddedPkg/GdbStub/SerialIo.c
@@ -457,7 +457,7 @@ GDB_SERIAL_DEV  gdbSerialDevTemplate = {
     0, // ControlMask
     0, // Timeout
     0, // BaudRate
-    1, // RceiveFifoDepth
+    1, // ReceiveFifoDepth
     0, // DataBits
     0, // Parity
     0  // StopBits

--- a/EmbeddedPkg/Include/libfdt.h
+++ b/EmbeddedPkg/Include/libfdt.h
@@ -735,7 +735,7 @@ fdt_get_property_w (
  * to within the device blob itself, not a copy of the value).  If
  * lenp is non-NULL, the length of the property value is also
  * returned, in the integer pointed to by lenp.  If namep is non-NULL,
- * the property's namne will also be returned in the char * pointed to
+ * the property's name will also be returned in the char * pointed to
  * by namep (this will be a pointer to within the device tree's string
  * block, not a new copy of the name).
  *
@@ -2246,7 +2246,7 @@ fdt_add_subnode_namelen (
  * change the offsets of some existing nodes.
 
  * returns:
- *      structure block offset of the created nodeequested subnode (>=0), on
+ *      structure block offset of the created noderequested subnode (>=0), on
  *              success
  *      -FDT_ERR_NOTFOUND, if the requested subnode does not exist
  *      -FDT_ERR_BADOFFSET, if parentoffset did not point to an FDT_BEGIN_NODE
@@ -2311,7 +2311,7 @@ fdt_del_node (
  * returns:
  *      0, on success
  *      -FDT_ERR_NOSPACE, there's not enough space in the base device tree
- *      -FDT_ERR_NOTFOUND, the overlay points to some inexistant nodes or
+ *      -FDT_ERR_NOTFOUND, the overlay points to some non existant nodes or
  *              properties in the base DT
  *      -FDT_ERR_BADPHANDLE,
  *      -FDT_ERR_BADOVERLAY,

--- a/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.c
+++ b/EmbeddedPkg/Library/AndroidBootImgLib/AndroidBootImgLib.c
@@ -175,7 +175,7 @@ AndroidBootImgGetImgSize (
   /* The page size is not specified, but it should be power of 2 at least */
   ASSERT (IS_VALID_ANDROID_PAGE_SIZE (Header->PageSize));
 
-  /* Get real size of abootimg */
+  /* Get real size of boot img */
   *ImgSize = ALIGN_VALUE (Header->KernelSize, Header->PageSize) +
              ALIGN_VALUE (Header->RamdiskSize, Header->PageSize) +
              ALIGN_VALUE (Header->SecondStageBootloaderSize, Header->PageSize) +

--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -2,7 +2,7 @@
  *
  *  Implement virtual EFI RealTimeClock runtime services.
  *
- *  Coypright (c) 2019, Pete Batard <pete@akeo.ie>
+ *  Copyright (c) 2019, Pete Batard <pete@akeo.ie>
  *  Copyright (c) 2018, Andrei Warkentin <andrey.warkentin@gmail.com>
  *  Copyright (c) 2011-2021, ARM Ltd. All rights reserved.
  *  Copyright (c) 2008-2010, Apple Inc. All rights reserved.

--- a/EmbeddedPkg/SimpleTextInOutSerial/SimpleTextInOut.c
+++ b/EmbeddedPkg/SimpleTextInOutSerial/SimpleTextInOut.c
@@ -554,7 +554,7 @@ OutputString (
             Mode->CursorRow++;
           }
 
-          // CHAR_CARIAGE_RETURN
+          // CHAR_CARRIAGE_RETURN
           Mode->CursorColumn = 0;
         } else {
           Mode->CursorColumn++;

--- a/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
@@ -247,7 +247,7 @@ MmcIoBlocks (
   UINTN                  Cmd;
   MMC_HOST_INSTANCE      *MmcHostInstance;
   EFI_MMC_HOST_PROTOCOL  *MmcHost;
-  UINTN                  BytesRemainingToBeTransfered;
+  UINTN                  BytesRemainingToBeTransferred;
   UINTN                  BlockCount;
   UINTN                  ConsumeSize;
   UINT32                 MaxBlock;
@@ -301,10 +301,10 @@ MmcIoBlocks (
   }
 
   // Max block number in single cmd is 65535 blocks.
-  MaxBlock                     = 0xFFFF;
-  RemainingBlock               = BlockCount;
-  BytesRemainingToBeTransfered = BufferSize;
-  while (BytesRemainingToBeTransfered > 0) {
+  MaxBlock                      = 0xFFFF;
+  RemainingBlock                = BlockCount;
+  BytesRemainingToBeTransferred = BufferSize;
+  while (BytesRemainingToBeTransferred > 0) {
     if (RemainingBlock <= MaxBlock) {
       BlockCount = RemainingBlock;
     } else {
@@ -349,8 +349,8 @@ MmcIoBlocks (
     }
 
     ConsumeSize = BlockCount * This->Media->BlockSize;
-    if (BytesRemainingToBeTransfered < ConsumeSize) {
-      ConsumeSize = BytesRemainingToBeTransfered;
+    if (BytesRemainingToBeTransferred < ConsumeSize) {
+      ConsumeSize = BytesRemainingToBeTransferred;
     }
 
     Status = MmcTransferBlock (This, Cmd, Transfer, MediaId, Lba, ConsumeSize, Buffer);
@@ -358,9 +358,9 @@ MmcIoBlocks (
       DEBUG ((DEBUG_ERROR, "%a(): Failed to transfer block and Status:%r\n", __func__, Status));
     }
 
-    RemainingBlock               -= BlockCount;
-    BytesRemainingToBeTransfered -= ConsumeSize;
-    if (BytesRemainingToBeTransfered > 0) {
+    RemainingBlock                -= BlockCount;
+    BytesRemainingToBeTransferred -= ConsumeSize;
+    if (BytesRemainingToBeTransferred > 0) {
       Lba   += BlockCount;
       Buffer = (UINT8 *)Buffer + ConsumeSize;
     }

--- a/SecurityPkg/Include/Library/OemTpm2InitLib.h
+++ b/SecurityPkg/Include/Library/OemTpm2InitLib.h
@@ -93,7 +93,7 @@ OemTpm2InitDxeEntryPreRegistration (
   NOTE: If this function returns an EFI_ERROR, TPM initialization WILL NOT continue.
         Make sure this is something you actually want to do.
 
-  @param[in]  BootAttemptCount  Number of ReadyToBoot events that have occured.
+  @param[in]  BootAttemptCount  Number of ReadyToBoot events that have occurred.
                                 0 indicates that this is the first ReadyToBoot event and
                                 is where most of any custom initialization should occur.
 

--- a/SecurityPkg/Include/Library/PlatformPKProtectionLib.h
+++ b/SecurityPkg/Include/Library/PlatformPKProtectionLib.h
@@ -19,7 +19,7 @@
 
   @retval     EFI_SUCCESS             State has been successfully updated.
   @retval     Others                  Error returned from implementation specific
-                                      underying APIs.
+                                      underlying APIs.
 
 **/
 EFI_STATUS

--- a/SecurityPkg/Include/Library/Tpm2CommandLib.h
+++ b/SecurityPkg/Include/Library/Tpm2CommandLib.h
@@ -1161,7 +1161,7 @@ CopyDigestListToBuffer (
   @param[in,out] DigestList         TPML_DIGEST_VALUES.
 
   @return EFI_STATUS
-  @retval EFI_SUCCESS               Buffer was succesfully copied to Digest List.
+  @retval EFI_SUCCESS               Buffer was successfully copied to Digest List.
   @retval EFI_BAD_BUFFER_SIZE       Bad buffer size passed to function.
   @retval EFI_INVALID_PARAMETER     Invalid parameter passed to function: NULL pointer or
                                     BufferSize bigger than TPML_DIGEST_VALUES

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceMinimumLib/DxeTcg2PhysicalPresenceMinimumLib.inf
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceMinimumLib/DxeTcg2PhysicalPresenceMinimumLib.inf
@@ -9,10 +9,8 @@
 #
 ##
 
-#Override : 00000001 | SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf | 6205753f2abf9126f2711c5f154f9f99 | 2021-01-09T19-05-15
-# This is not a true override, but as this is derived from the full-featured lib, we want to track if any bugs are fixed there to ensure they are fixed here
-# A minimized version of the TCG2 Physical Presence Library that implements only the features that are required by the TCG PPI 1.3 spec,
-# optional features are removed, the only supported function is to Clear the TPM, and is always approved with no UX
+#Override : 00000002 | SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf | 6205753f2abf9126f2711c5f154f9f99 | 2024-07-24T18-06-30 | 69ff4b6fc889c8e66101cad3dcf8be3d516e038d
+# This is not a true override, but spell changes to ensure mu_tiano_plus passes CI is required and changes the hash.
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/SecurityPkg/Library/DxeTpmMeasureBootLib/InternalUnitTest/DxeTpmMeasureBootLibSanitizationTest.c
+++ b/SecurityPkg/Library/DxeTpmMeasureBootLib/InternalUnitTest/DxeTpmMeasureBootLibSanitizationTest.c
@@ -287,7 +287,7 @@ TestSanitizePeImageEventSize (
   // Test that the event size may not overflow
   Status = TpmSanitizePeImageEventSize (MAX_UINT32, &EventSize);
   if (Status != EFI_BAD_BUFFER_SIZE) {
-    UT_LOG_ERROR ("SanitizePeImageEventSize succeded when it was supposed to fail with %r\n", Status);
+    UT_LOG_ERROR ("SanitizePeImageEventSize succeeded when it was supposed to fail with %r\n", Status);
     goto Exit;
   }
 

--- a/SecurityPkg/Library/OemTpm2InitLibNull/OemTpm2InitLib.c
+++ b/SecurityPkg/Library/OemTpm2InitLibNull/OemTpm2InitLib.c
@@ -51,7 +51,7 @@ OemTpm2InitPeiPreStartup (
 
   IMPLEMENTATION: Read the TPM Enablement NV Index from the TPM itself.
     - If enabled, allow init to continue.
-    - If read fails because NV Index missing or uninitialzed:
+    - If read fails because NV Index missing or uninitialized:
       - If missing, create and initialize.
       - If uninitialized, set to default value (TPM ON)
     - If disabled, discontinue TPM init.
@@ -128,7 +128,7 @@ OemTpm2InitDxeEntryPreRegistration (
   NOTE: If this function returns an EFI_ERROR, TPM initialization WILL NOT continue.
         Make sure this is something you actually want to do.
 
-  @param[in]  BootAttemptCount  Number of ReadyToBoot events that have occured.
+  @param[in]  BootAttemptCount  Number of ReadyToBoot events that have occurred.
                                 0 indicates that this is the first ReadyToBoot event and
                                 is where most of any custom initialization should occur.
 

--- a/SecurityPkg/Library/PlatformPKProtectionLibVarPolicy/PlatformPKProtectionLibVarPolicy.c
+++ b/SecurityPkg/Library/PlatformPKProtectionLibVarPolicy/PlatformPKProtectionLibVarPolicy.c
@@ -21,7 +21,7 @@
 
   @retval     EFI_SUCCESS             State has been successfully updated.
   @retval     Others                  Error returned from implementation specific
-                                      underying APIs.
+                                      underlying APIs.
 
 **/
 EFI_STATUS

--- a/SecurityPkg/Library/SecureBootVariableLib/UnitTest/MockPlatformPKProtectionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/UnitTest/MockPlatformPKProtectionLib.c
@@ -23,7 +23,7 @@
 
   @retval     EFI_SUCCESS             State has been successfully updated.
   @retval     Others                  Error returned from implementation specific
-                                      underying APIs.
+                                      underlying APIs.
 
 **/
 EFI_STATUS

--- a/SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.c
@@ -62,7 +62,7 @@ extern EFI_TIME  mDefaultPayloadTimestamp;
   @retval EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
   @retval EFI_WRITE_PROTECTED    The variable in question is read-only.
   @retval EFI_WRITE_PROTECTED    The variable in question cannot be deleted.
-  @retval EFI_SECURITY_VIOLATION The variable could not be written due to EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACESS being set,
+  @retval EFI_SECURITY_VIOLATION The variable could not be written due to EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS being set,
                                  but the AuthInfo does NOT pass the validation check carried out by the firmware.
 
   @retval EFI_NOT_FOUND          The variable trying to be updated or deleted was not found.
@@ -1928,7 +1928,7 @@ SetSecureBootVariablesDBTOptional (
 }
 
 /**
-  Initialze the unit test framework, suite, and unit tests for the
+  Initialize the unit test framework, suite, and unit tests for the
   SecureBootVariableLib and run the SecureBootVariableLib unit test.
 
   @retval  EFI_SUCCESS           All test cases were dispatched.

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Provides interface for firmwware TPM measurement
+#  Provides interface for firmware TPM measurement
 #
 # Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Help.c
@@ -301,7 +301,7 @@ CopyDigestListToBuffer (
   @param[in,out] DigestList         TPML_DIGEST_VALUES.
 
   @return EFI_STATUS
-  @retval EFI_SUCCESS               Buffer was succesfully copied to Digest List.
+  @retval EFI_SUCCESS               Buffer was successfully copied to Digest List.
   @retval EFI_BAD_BUFFER_SIZE       Bad buffer size passed to function.
   @retval EFI_INVALID_PARAMETER     Invalid parameter passed to function: NULL pointer or
                                     BufferSize bigger than TPML_DIGEST_VALUES

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Hierarchy.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Hierarchy.c
@@ -278,7 +278,7 @@ Tpm2Clear (
   }
 
   //
-  // Unmarshal the response
+  // un-Marshal the response
   //
 
   // None
@@ -372,7 +372,7 @@ Tpm2ClearControl (
   }
 
   //
-  // Unmarshal the response
+  // un-Marshal the response
   //
 
   // None

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
@@ -195,7 +195,7 @@ Tpm2PcrExtend (
   DEBUG_CODE_END ();
 
   //
-  // Unmarshal the response
+  // Un-marshal the response
   //
 
   // None
@@ -290,7 +290,7 @@ Tpm2PcrEvent (
   }
 
   //
-  // Unmarshal the response
+  // Un-marshal the response
   //
   Buffer = (UINT8 *)&Res.Digests;
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Sequences.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Sequences.c
@@ -156,7 +156,7 @@ Tpm2HashSequenceStart (
   }
 
   //
-  // Unmarshal the response
+  // Un-marshal the response
   //
 
   // sequenceHandle
@@ -253,7 +253,7 @@ Tpm2SequenceUpdate (
   }
 
   //
-  // Unmarshal the response
+  // Un-marshal the response
   //
 
   // None
@@ -362,7 +362,7 @@ Tpm2EventSequenceComplete (
   }
 
   //
-  // Unmarshal the response
+  // Un-marshal the response
   //
 
   BufferPtr = (UINT8 *)&Res.Results;
@@ -489,7 +489,7 @@ Tpm2SequenceComplete (
   }
 
   //
-  // Unmarshal the response
+  // Un-marshal the response
   //
 
   BufferPtr = (UINT8 *)&Res.Digest;

--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
@@ -195,7 +195,7 @@ ExchangeCommonBuffer (
   // Step 1: Grab the common buffer header
   Status = EfiGetSystemConfigurationTable (&gEdkiiPiSmmCommunicationRegionTableGuid, (VOID **)&PiSmmCommunicationRegionTable);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - Failed to locate SMM communciation common buffer - %r!\n", __func__, Status));
+    DEBUG ((DEBUG_ERROR, "%a - Failed to locate SMM communication common buffer - %r!\n", __func__, Status));
     return Status;
   }
 
@@ -318,11 +318,11 @@ UpdatePossibleResource (
   UINT8   *DataPtr;
   UINT8   *DataEndPtr;
   UINT32  NewPkgLength;
-  UINT32  OrignalPkgLength;
+  UINT32  OriginalPkgLength;
 
-  NewPkgLength     = 0;
-  OrignalPkgLength = 0;
-  DataEndPtr       = NULL;
+  NewPkgLength      = 0;
+  OriginalPkgLength = 0;
+  DataEndPtr        = NULL;
 
   //
   // Follow ACPI spec
@@ -373,8 +373,8 @@ UpdatePossibleResource (
       DataPtr += TPM_PRS_RES_NAME_SIZE + 1;
 
       if ((*DataPtr & (BIT7|BIT6)) == 0) {
-        OrignalPkgLength = (UINT32)*DataPtr;
-        DataEndPtr       = DataPtr + OrignalPkgLength;
+        OriginalPkgLength = (UINT32)*DataPtr;
+        DataEndPtr        = DataPtr + OriginalPkgLength;
 
         //
         // Jump over PkgLength = PkgLeadByte only
@@ -407,7 +407,7 @@ UpdatePossibleResource (
         break;
       }
 
-      if (NewPkgLength > OrignalPkgLength) {
+      if (NewPkgLength > OriginalPkgLength) {
         ASSERT (FALSE);
         return EFI_INVALID_PARAMETER;
       }
@@ -436,8 +436,8 @@ UpdatePossibleResource (
   // 2. Use TPM_PRS_RESL with PkgLength > 63 to hold longer input interrupt number buffer for patching
   //
   if (NewPkgLength > 63) {
-    NewPkgLength     = 0;
-    OrignalPkgLength = 0;
+    NewPkgLength      = 0;
+    OriginalPkgLength = 0;
     for (DataPtr  = (UINT8 *)(Table + 1);
          DataPtr < (UINT8 *)((UINT8 *)Table + Table->Length - (TPM_PRS_RES_NAME_SIZE + TPM_POS_RES_TEMPLATE_MIN_SIZE));
          DataPtr += 1)
@@ -449,8 +449,8 @@ UpdatePossibleResource (
         DataPtr += TPM_PRS_RES_NAME_SIZE + 1;
 
         if ((*DataPtr & (BIT7|BIT6)) != 0) {
-          OrignalPkgLength = (UINT32)(*(DataPtr + 1) << 4) + (*DataPtr & 0x0F);
-          DataEndPtr       = DataPtr + OrignalPkgLength;
+          OriginalPkgLength = (UINT32)(*(DataPtr + 1) << 4) + (*DataPtr & 0x0F);
+          DataEndPtr        = DataPtr + OriginalPkgLength;
           //
           // Jump over PkgLength = PkgLeadByte + ByteData length
           //
@@ -479,7 +479,7 @@ UpdatePossibleResource (
         //
         NewPkgLength += 19 + IrqBuffserSize;
 
-        if (NewPkgLength > OrignalPkgLength) {
+        if (NewPkgLength > OriginalPkgLength) {
           ASSERT (FALSE);
           return EFI_INVALID_PARAMETER;
         }

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -258,8 +258,8 @@ EndofPeiSignalNotifyCallBack (
     CopyMem (&MeasuredHobData->MeasuredFvBuf[mMeasuredBaseFvIndex], mMeasuredChildFvInfo, sizeof (EFI_PLATFORM_FIRMWARE_BLOB) * (mMeasuredChildFvIndex));
   }
 
-  // MU_CHANGE - START
-  // Create a guid hob to save all excluded FVs for DXE - mschange start
+  //
+  // Create a guid hob to save all excluded FVs for DXE - MU_CHANGE - START
   //
 
   //

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -350,7 +350,7 @@ CheckX509Certificate (
   //
   Status = ReadFileContent (X509FileContext->FHandle, (VOID **)&X509Data, &X509DataSize, 0);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Error occured while reading the file.\n"));
+    DEBUG ((DEBUG_ERROR, "Error occurred while reading the file.\n"));
     goto ON_EXIT;
   }
 
@@ -358,7 +358,7 @@ CheckX509Certificate (
   // Parse the public key context.
   //
   if (RsaGetPublicKeyFromX509 (X509Data, X509DataSize, &X509PubKey) == FALSE) {
-    DEBUG ((DEBUG_ERROR, "Error occured while parsing the pubkey from certificate.\n"));
+    DEBUG ((DEBUG_ERROR, "Error occurred while parsing the pubkey from certificate.\n"));
     Status = EFI_INVALID_PARAMETER;
     *Error = Unsupported_Type;
     goto ON_EXIT;
@@ -3993,7 +3993,7 @@ ON_EXIT:
 
 /**
   Format the help info for the signature data, each help info contain 3 parts.
-  1. Onwer Guid.
+  1. Owner Guid.
   2. Content, depends on the type of the signature list.
   3. Revocation time.
 


### PR DESCRIPTION
## Description

This PR pulls all the cspell commits from release/202311 and combines them into one commit with all the changes.  Many of these are minor and inconsequential.

Commits for reference

---

820b09b : Require cpsell 5.20.0

---

3ef1a32 : Corrects spelling error in unit test

---

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with CI

## Integration Instructions

N/A