### PR TITLE
[CHERRY-PICK] [REBASE & FF] Revert Mu Commit in Favor of Edk2 Commit

### DIFF
--- a/FatPkg/EnhancedFatDxe/DiskCache.c
+++ b/FatPkg/EnhancedFatDxe/DiskCache.c
@@ -8,215 +8,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "Fat.h"
 
-//
-// MU_CHANGE begin
-//
-// Keep track of Lba blocks within a cache line.  Allow reads from the disk to read the
-// full cache line, and all writes to the cache line will update which Lba is dirty in DIRTY_BITS
-//
-// At flush time, when the cache line is written out, only write the blocks that are dirty, coalescing
-// adjacent writes to a single FatDiskIo write.
-//
-
-/**
-  IsCacheTagDirty    - Checks if any LBA is dirty in this cache line
-
-  @param[in]    CacheTag   - CacheTag to check
-
-  @retval       TRUE       - Cache is Dirty
-                FALSE      - Cache is not Dirty
-
-**/
-STATIC
-BOOLEAN
-IsCacheTagDirty (
-  IN CACHE_TAG  *CacheTag
-  )
-{
-  UINTN  i;
-
-  for (i = 0; i < DIRTY_BLOCKS_SIZE; i++) {
-    if (CacheTag->DirtyBlocks[i]) {
-      return TRUE;
-    }
-  }
-
-  return FALSE;
-}
-
-/**
-  SetBitInDirtyBlock
-
-  @param[in]    BitNumber      - Which bit to set in DirtyBlocks
-  @param[in]    DirtyBlocks    - Array of bits
-
-**/
-STATIC
-VOID
-SetBitInDirtyBlock (
-  IN UINTN         BitNumber,
-  IN DIRTY_BLOCKS  *DirtyBlocks
-  )
-{
-  UINTN  BlockIndex;
-  UINTN  BitIndex;
-
-  //
-  // ASSERTs checking BitNumber are DEBUG build only to verify the assumptions in the
-  // fat.h defines (See fat.h lines to describe DIRTY_BITS)
-  //
-  ASSERT (BitNumber < DIRTY_BITS);
-
-  BlockIndex               = BitNumber / DIRTY_BITS_PER_BLOCK;
-  BitIndex                 = BitNumber % DIRTY_BITS_PER_BLOCK;
-  DirtyBlocks[BlockIndex] |= (DIRTY_BLOCKS)((UINTN)1ull << BitIndex);
-}
-
-/**
-  CheckBitInDirtyBlock
-
-  @param[in]    BitNumber      - Which bit to check in DirtyBlocks
-  @param[in]    DirtyBlocks    - Array of bits
-
-**/
-STATIC
-BOOLEAN
-CheckBitInDirtyBlock (
-  IN UINTN         BitNumber,
-  IN DIRTY_BLOCKS  *DirtyBlocks
-  )
-{
-  UINTN  BlockIndex;
-  UINTN  BitIndex;
-
-  ASSERT (BitNumber < DIRTY_BITS);
-
-  BlockIndex = BitNumber / DIRTY_BITS_PER_BLOCK;
-  BitIndex   = BitNumber % DIRTY_BITS_PER_BLOCK;
-  return (DirtyBlocks[BlockIndex] & (DIRTY_BLOCKS)((UINTN)1ull << BitIndex)) != 0;
-}
-
-/**
-  SetCacheTagDirty   - Sets dirty block bits
-
-  @param[in]    DiskCache  - DiskCache
-  @param[in]    CacheTag   - CacheTag to update
-  @param[in]    Offset     - Offset in the cache line to be marked modified
-  @param[in]    Length     - Length of the data to be marked modified
-
-**/
-STATIC
-VOID
-SetCacheTagDirty (
-  IN DISK_CACHE  *DiskCache,
-  IN CACHE_TAG   *CacheTag,
-  IN UINTN       Offset,
-  IN UINTN       Length
-  )
-{
-  UINTN  Bit;
-  UINTN  LastBit;
-
-  Bit     = Offset / DiskCache->BlockSize;
-  LastBit = (Offset + Length - 1) / DiskCache->BlockSize;
-
-  ASSERT (Bit <= LastBit);
-  ASSERT (LastBit <= DIRTY_BITS);
-
-  do {
-    SetBitInDirtyBlock (Bit, CacheTag->DirtyBlocks);
-  } while (++Bit <= LastBit);
-}
-
-/**
-
-  Cache version of FatDiskIo for writing only those LBA's with dirty data.
-
-  @param  DiskCache             - FAT file system VolumeDiskCachevolume.
-  @param  Volume                - FAT file system volume.
-  @param  Volume                - FAT file system volume.
-  @param  IoMode                - The access mode (disk read/write or cache access).
-  @param  Offset                - The starting byte offset to read from.
-  @param  BufferSize            - Size of Buffer.
-  @param  Buffer                - Buffer containing read data.
-  @param  Task                    point to task instance.
-
-  @retval EFI_SUCCESS           - The operation is performed successfully.
-  @retval EFI_VOLUME_CORRUPTED  - The access is
-  @return Others                - The status of read/write the disk
-
-**/
-STATIC
-EFI_STATUS
-CacheFatDiskIo (
-  IN     CACHE_TAG        *CacheTag,
-  IN     CACHE_DATA_TYPE  DataType,
-  IN     FAT_VOLUME       *Volume,
-  IN     IO_MODE          IoMode,
-  IN     UINT64           Offset,
-  IN     UINTN            BufferSize,
-  IN OUT VOID             *Buffer,
-  IN     FAT_TASK         *Task
-  )
-{
-  DISK_CACHE  *DiskCache;
-  UINTN       Bit;
-  VOID        *WriteBuffer;
-  UINTN       LastBit;
-  UINT64      StartPos;
-  EFI_STATUS  Status;
-  UINTN       WriteSize;
-
-  Status = EFI_SUCCESS;
-  if ((IoMode == WriteDisk) && (CacheTag->RealSize != 0)) {
-    DiskCache   = &Volume->DiskCache[DataType];
-    WriteBuffer = Buffer;
-    LastBit     = (CacheTag->RealSize - 1) / DiskCache->BlockSize;
-    StartPos    = Offset;
-    Bit         = 0;
-    WriteSize   = 0;
-
-    do {
-      if (CheckBitInDirtyBlock (Bit, CacheTag->DirtyBlocks)) {
-        do {
-          WriteSize += DiskCache->BlockSize;
-          Bit++;
-          if (Bit > LastBit) {
-            break;
-          }
-        } while (CheckBitInDirtyBlock (Bit, CacheTag->DirtyBlocks));
-
-        Status = FatDiskIo (Volume, IoMode, StartPos, WriteSize, WriteBuffer, Task);
-        if (EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        StartPos   += WriteSize + DiskCache->BlockSize;
-        WriteBuffer = (VOID *)((UINTN)WriteBuffer + WriteSize + DiskCache->BlockSize);
-        WriteSize   = 0;
-        Bit++;
-      } else {
-        StartPos   += DiskCache->BlockSize;
-        WriteBuffer = (VOID *)((UINTN)WriteBuffer + DiskCache->BlockSize);
-        Bit++;
-      }
-    } while (Bit <= LastBit);
-
-    ASSERT (WriteSize == 0);
-  } else {
-    Status = FatDiskIo (Volume, IoMode, Offset, BufferSize, Buffer, Task);
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  return Status;
-}
-
-//
-// MU_CHANGE end
-//
-
 /**
 
   This function is used by the Data Cache.
@@ -266,14 +57,12 @@ FatFlushDataCacheRange (
     CacheTag = &DiskCache->CacheTag[GroupNo];
     if ((CacheTag->RealSize > 0) && (CacheTag->PageNo == PageNo)) {
       //
-      // MU_CHANGE: Fix spelling
-      // When reading data from disk directly, if some dirty data
-      // in cache is in this range, this data in the Buffer needs to
+      // When reading data form disk directly, if some dirty data
+      // in cache is in this rang, this data in the Buffer need to
       // be updated with the cache's dirty data.
       //
       if (IoMode == ReadDisk) {
-        // MU_CHANGE
-        if (IsCacheTagDirty (CacheTag)) {
+        if (CacheTag->Dirty) {
           CopyMem (
             Buffer + ((PageNo - StartPageNo) << PageAlignment),
             BaseAddress + (GroupNo << PageAlignment),
@@ -350,7 +139,7 @@ FatExchangeCachePage (
     //
     // Only fat table writing will execute more than once
     //
-    Status = CacheFatDiskIo (CacheTag, DataType, Volume, IoMode, EntryPos, RealSize, PageAddress, Task);  // MU_CHANGE
+    Status = FatDiskIo (Volume, IoMode, EntryPos, RealSize, PageAddress, Task);
     if (EFI_ERROR (Status)) {
       return Status;
     }
@@ -358,7 +147,7 @@ FatExchangeCachePage (
     EntryPos += Volume->FatSize;
   } while (--WriteCount > 0);
 
-  SetMem (CacheTag->DirtyBlocks, sizeof (CacheTag->DirtyBlocks), 0);  // MU_CHANGE Set all cache blocks as not dirty
+  CacheTag->Dirty    = FALSE;
   CacheTag->RealSize = RealSize;
   return EFI_SUCCESS;
 }
@@ -399,8 +188,7 @@ FatGetCachePage (
   //
   // Write dirty cache page back to disk
   //
-  // MU_CHANGE
-  if ((CacheTag->RealSize > 0) && IsCacheTagDirty (CacheTag)) {
+  if ((CacheTag->RealSize > 0) && CacheTag->Dirty) {
     Status = FatExchangeCachePage (Volume, CacheDataType, WriteDisk, CacheTag, NULL);
     if (EFI_ERROR (Status)) {
       return Status;
@@ -460,7 +248,7 @@ FatAccessUnalignedCachePage (
     Source      = DiskCache->CacheBase + (GroupNo << DiskCache->PageAlignment) + Offset;
     Destination = Buffer;
     if (IoMode != ReadDisk) {
-      SetCacheTagDirty (DiskCache, CacheTag, Offset, Length);    // MU_CHANGE
+      CacheTag->Dirty  = TRUE;
       DiskCache->Dirty = TRUE;
       Destination      = Source;
       Source           = Buffer;
@@ -625,8 +413,7 @@ FatVolumeFlushCache (
       GroupMask = DiskCache->GroupMask;
       for (GroupIndex = 0; GroupIndex <= GroupMask; GroupIndex++) {
         CacheTag = &DiskCache->CacheTag[GroupIndex];
-        // MU_CHANGE
-        if ((CacheTag->RealSize > 0) && IsCacheTagDirty (CacheTag)) {
+        if ((CacheTag->RealSize > 0) && CacheTag->Dirty) {
           //
           // Write back all Dirty Data Cache Page to disk
           //
@@ -702,9 +489,5 @@ FatInitializeDiskCache (
   Volume->CacheBuffer            = CacheBuffer;
   DiskCache[CacheFat].CacheBase  = CacheBuffer;
   DiskCache[CacheData].CacheBase = CacheBuffer + FatCacheSize;
-
-  DiskCache[CacheFat].BlockSize  = Volume->BlockIo->Media->BlockSize;     // MU_CHANGE
-  DiskCache[CacheData].BlockSize = Volume->BlockIo->Media->BlockSize;     // MU_CHANGE
-
   return EFI_SUCCESS;
 }

--- a/FatPkg/EnhancedFatDxe/Fat.h
+++ b/FatPkg/EnhancedFatDxe/Fat.h
@@ -84,23 +84,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FAT_FATCACHE_GROUP_MIN_COUNT      1
 #define FAT_FATCACHE_GROUP_MAX_COUNT      16
 
-// MU_CHANGE begin
-
-// For cache block bits, use CPU native size
-#define DIRTY_BLOCKS          UINTN
-#define BITS_PER_BYTE         8
-#define DIRTY_BITS_PER_BLOCK  (sizeof(DIRTY_BLOCKS) * BITS_PER_BYTE)
-
-// largest cache line (64KB) / MinLbaSize (512) = 128 bits
-#define DIRTY_BITS  ((1 << FAT_DATACACHE_PAGE_MAX_ALIGNMENT) / (1 << MIN_BLOCK_ALIGNMENT))
-
-// Number of DIRTY_BLOCKS to hold DIRTY_BITS bits.
-#define DIRTY_BLOCKS_SIZE  (DIRTY_BITS / sizeof (DIRTY_BLOCKS))
-
-STATIC_ASSERT ((((1 << FAT_DATACACHE_PAGE_MAX_ALIGNMENT) / (1 << MIN_BLOCK_ALIGNMENT)) % sizeof (DIRTY_BLOCKS)) == 0, "DIRTY_BLOCKS not a proper size");
-
-// MU_CHANGE end
-
 //
 // Used in 8.3 generation algorithm
 //
@@ -160,16 +143,15 @@ typedef enum {
 // Disk cache tag
 //
 typedef struct {
-  UINTN           PageNo;                         // MU_CHANGE
-  UINTN           RealSize;                       // MU_CHANGE
-  DIRTY_BLOCKS    DirtyBlocks[DIRTY_BLOCKS_SIZE]; // MU_CHANGE
+  UINTN      PageNo;
+  UINTN      RealSize;
+  BOOLEAN    Dirty;
 } CACHE_TAG;
 
 typedef struct {
   UINT64       BaseAddress;
   UINT64       LimitAddress;
   UINT8        *CacheBase;
-  UINT32       BlockSize;                        // MU_CHANGE
   BOOLEAN      Dirty;
   UINT8        PageAlignment;
   UINTN        GroupMask;

--- a/FatPkg/EnhancedFatDxe/Init.c
+++ b/FatPkg/EnhancedFatDxe/Init.c
@@ -61,6 +61,30 @@ FatAllocateVolume (
   //
   Volume->RootDirEnt.FileString       = Volume->RootFileString;
   Volume->RootDirEnt.Entry.Attributes = FAT_ATTRIBUTE_DIRECTORY;
+
+  //
+  // Check to see if the underlying block device's BlockSize meets what the FAT spec requires
+  //
+  if ((BlockIo == NULL) || (BlockIo->Media == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a BlockIo or BlockIo is NULL!\n", __func__));
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  if ((BlockIo->Media->BlockSize > (1 << MAX_BLOCK_ALIGNMENT)) ||
+      (BlockIo->Media->BlockSize < (1 << MIN_BLOCK_ALIGNMENT)))
+  {
+    Status = EFI_UNSUPPORTED;
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a invalid BlockIo BlockSize %u for FAT filesystem on MediaId %u. Min 512b, max 4kb\n",
+      __func__,
+      BlockIo->Media->BlockSize,
+      BlockIo->Media->MediaId
+      ));
+    goto Done;
+  }
+
   //
   // Check to see if there's a file system on the volume
   //

--- a/FatPkg/EnhancedFatDxe/Init.c
+++ b/FatPkg/EnhancedFatDxe/Init.c
@@ -62,22 +62,24 @@ FatAllocateVolume (
   Volume->RootDirEnt.FileString       = Volume->RootFileString;
   Volume->RootDirEnt.Entry.Attributes = FAT_ATTRIBUTE_DIRECTORY;
 
-  //
-  // Check to see if the underlying block device's BlockSize meets what the FAT spec requires
-  //
   if ((BlockIo == NULL) || (BlockIo->Media == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a BlockIo or BlockIo is NULL!\n", __func__));
     Status = EFI_INVALID_PARAMETER;
     goto Done;
   }
 
-  if ((BlockIo->Media->BlockSize > (1 << MAX_BLOCK_ALIGNMENT)) ||
-      (BlockIo->Media->BlockSize < (1 << MIN_BLOCK_ALIGNMENT)))
+  //
+  // Check to see if the underlying block device's BlockSize meets what the FAT spec requires
+  //
+  if ((BlockIo->Media->BlockSize != 512) &&
+      (BlockIo->Media->BlockSize != SIZE_1KB) &&
+      (BlockIo->Media->BlockSize != SIZE_2KB) &&
+      (BlockIo->Media->BlockSize != SIZE_4KB))
   {
     Status = EFI_UNSUPPORTED;
     DEBUG ((
       DEBUG_ERROR,
-      "%a invalid BlockIo BlockSize %u for FAT filesystem on MediaId %u. Min 512b, max 4kb\n",
+      "%a invalid BlockIo BlockSize %u for FAT filesystem on MediaId %u. Must be 512B, 1KB, 2KB, or 4KB\n",
       __func__,
       BlockIo->Media->BlockSize,
       BlockIo->Media->MediaId

--- a/FatPkg/FatPkg.ci.yaml
+++ b/FatPkg/FatPkg.ci.yaml
@@ -65,6 +65,7 @@
             "FFFFFFFFL",
             "CDVOL",
             "DMDEPKG",
+            "lba's",
             "loongarch",
             # MU_CHANGE - Start
             "loongson",


### PR DESCRIPTION
## Description

This reverts commit https://github.com/microsoft/mu_tiano_plus/commit/2c6a71aeff426a84b04eb40c530d6f581ea0b10f as
it was upstreamed to edk2 as two commits:
3ef6a71ed186d1e8e44c26c24a1cbea5533e3554 and
a131839a3db7f933f51efc6c13d5986d7f09eab3.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
