### PR TITLE
SecurityPkg: Add measurement of Firmware Debugger Enabled based on DeviceState

### DIFF
--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -95,6 +95,11 @@
   MemLibWrapper|SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
+  ## MU_CHANGE [BEGIN] - Measure Firmware Debugger Enabled
+  DeviceStateLib|MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf 
+  PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf 
+  # MU_CHANGE [END]
+
 [LibraryClasses.X64, LibraryClasses.IA32]
   Tcg2PreUefiEventLogLib|SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf  ## MU_CHANGE
 

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -71,6 +71,10 @@
   OemTpm2InitLib
 ## MU_CHANGE [END]
   PcdLib  # MU_CHANGE
+  ## MU_CHANGE [BEGIN] - Measure Firmware Debugger Enabled
+  DeviceStateLib
+  PanicLib
+  ## MU_CHANGE [END]
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"

--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
@@ -64,6 +64,10 @@
   Tcg2PreUefiEventLogLib
 ## MU_CHANGE [END]
 
+  ## MU_CHANGE [BEGIN] - Measure Firmware Debugger Enabled
+  DeviceStateLib
+  PanicLib
+  ## MU_CHANGE [END]
 [Guids]
   gTcgEventEntryHobGuid                                                ## PRODUCES               ## HOB
   gTpmErrorHobGuid                                                     ## SOMETIMES_PRODUCES     ## HOB


### PR DESCRIPTION
## Description

Add measurement of Firmware Debugger
Enabled based on DeviceState.

Added both to Tcg2Pei and Tcg2Dxe. The measurement is redundant
in Tcg2Dxe, but is added for consistency with previous functionality.
The plan is to remove the PcdFirmwareDebuggerInitialized PCD
and replace its usage with the DeviceStateLib

This will prevent the system from booting if the device is in an
an insecure state, as determined by the DeviceStateLib from
MdeModulePkg.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI

## Integration Instructions
N/A