### PR TITLE
SecurityPkg: Remove PcdFirmwareDebuggerInitialized

### DIFF
--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -446,12 +446,14 @@
   # @Prompt Enable hardware method of asserting physical presence.
   gEfiSecurityPkgTokenSpaceGuid.PcdPhysicalPresenceHwEnable|TRUE|BOOLEAN|0x00010005
 
-[PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
+  # MU_CHANGE [BEGIN] - Remove PcdFirmwareDebuggerInitialized
+# [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD indicates if debugger exists. <BR><BR>
   #   TRUE  - Firmware debugger exists.<BR>
   #   FALSE - Firmware debugger doesn't exist.<BR>
   # @Prompt Firmware debugger status.
-  gEfiSecurityPkgTokenSpaceGuid.PcdFirmwareDebuggerInitialized|FALSE|BOOLEAN|0x00010009
+  # gEfiSecurityPkgTokenSpaceGuid.PcdFirmwareDebuggerInitialized|FALSE|BOOLEAN|0x00010009
+  # MU_CHANGE [END]
 
   ## This PCD indicates the initialization policy for TPM 2.0.<BR><BR>
   #  If 0, no initialization needed - most likely used for chipset SRTM solution, in which TPM is already initialized.<BR>

--- a/SecurityPkg/SecurityPkg.uni
+++ b/SecurityPkg/SecurityPkg.uni
@@ -101,12 +101,13 @@
 #string STR_gEfiSecurityPkgTokenSpaceGuid_PcdPhysicalPresenceHwEnable_HELP  #language en-US "Indicates whether the platform supports the hardware method of asserting physical presence.<BR><BR>\n"
                                                                                             "TRUE  - Supports the hardware method of asserting physical presence.<BR>\n"
                                                                                             "FALSE - Does not support the hardware method of asserting physical presence.<BR>"
-
-#string STR_gEfiSecurityPkgTokenSpaceGuid_PcdFirmwareDebuggerInitialized_PROMPT  #language en-US "Firmware debugger status."
-
-#string STR_gEfiSecurityPkgTokenSpaceGuid_PcdFirmwareDebuggerInitialized_HELP  #language en-US "This PCD indicates if debugger exists. <BR><BR>\n"
-                                                                                               "TRUE  - Firmware debugger exists.<BR>\n"
-                                                                                               "FALSE - Firmware debugger doesn't exist.<BR>"
+// MU_CHANGE [BEGIN] - Remove PcdFirmwareDebuggerInitialized
+// #string STR_gEfiSecurityPkgTokenSpaceGuid_PcdFirmwareDebuggerInitialized_PROMPT  #language en-US "Firmware debugger status."
+//
+// #string STR_gEfiSecurityPkgTokenSpaceGuid_PcdFirmwareDebuggerInitialized_HELP  #language en-US "This PCD indicates if debugger exists. <BR><BR>\n"
+//                                                                                               "TRUE  - Firmware debugger exists.<BR>\n"
+//                                                                                               "FALSE - Firmware debugger doesn't exist.<BR>"
+// MU_CHANGE [END]
 
 #string STR_gEfiSecurityPkgTokenSpaceGuid_PcdTpm2InitializationPolicy_PROMPT  #language en-US "TPM 2.0 device initialization policy.<BR>"
 

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -2525,10 +2525,12 @@ MeasureSecureBootPolicy (
 
   // MU_CHANGE [END]
 
-  if (PcdGetBool (PcdFirmwareDebuggerInitialized)) {
-    Status = MeasureLaunchOfFirmwareDebugger ();
-    DEBUG ((DEBUG_INFO, "MeasureLaunchOfFirmwareDebugger - %r\n", Status));
-  }
+  // MU_CHANGE [BEGIN] - Remove PcdFirmwareDebuggerInitialized
+  // if (PcdGetBool (PcdFirmwareDebuggerInitialized)) {
+  //  Status = MeasureLaunchOfFirmwareDebugger ();
+  //  DEBUG ((DEBUG_INFO, "MeasureLaunchOfFirmwareDebugger - %r\n", Status));
+  // }
+  // MU_CHANGE [END]
 
   Status = MeasureAllSecureVariables ();
   DEBUG ((DEBUG_INFO, "MeasureAllSecureVariables - %r\n", Status));

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -109,7 +109,7 @@
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmPlatformClass                         ## SOMETIMES_CONSUMES
-  gEfiSecurityPkgTokenSpaceGuid.PcdFirmwareDebuggerInitialized              ## SOMETIMES_CONSUMES
+  # gEfiSecurityPkgTokenSpaceGuid.PcdFirmwareDebuggerInitialized            ## SOMETIMES_CONSUMES # MU_CHANGE - Remove PCD
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                          ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeSubClassTpmDevice              ## SOMETIMES_CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap                  ## CONSUMES


### PR DESCRIPTION
## Description

Removed PCD in favor of using DeviceStateLib for
storing firmware debugger enablement status.

This PR is waiting on the removal of the Pcd's use here https://github.com/microsoft/mu_tiano_plus/pull/342
For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local CI

## Integration Instructions

Remove any usage of PcdFirmwareDebuggerInitialized.