### PR TITLE
Remove non-RT types from Mem Type Info Settings

### DIFF
--- a/EmbeddedPkg/Library/PrePiHobLib/Hob.c
+++ b/EmbeddedPkg/Library/PrePiHobLib/Hob.c
@@ -857,7 +857,8 @@ BuildMemoryTypeInformationHob (
   VOID
   )
 {
-  EFI_MEMORY_TYPE_INFORMATION  Info[10];
+  // MU_CHANGE [BEGIN] - Remove non-RT types from Mem Type Info Settings
+  EFI_MEMORY_TYPE_INFORMATION  Info[6];
 
   Info[0].Type          = EfiACPIReclaimMemory;
   Info[0].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiACPIReclaimMemory);
@@ -869,18 +870,10 @@ BuildMemoryTypeInformationHob (
   Info[3].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiRuntimeServicesData);
   Info[4].Type          = EfiRuntimeServicesCode;
   Info[4].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiRuntimeServicesCode);
-  Info[5].Type          = EfiBootServicesCode;
-  Info[5].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiBootServicesCode);
-  Info[6].Type          = EfiBootServicesData;
-  Info[6].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiBootServicesData);
-  Info[7].Type          = EfiLoaderCode;
-  Info[7].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiLoaderCode);
-  Info[8].Type          = EfiLoaderData;
-  Info[8].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiLoaderData);
-
   // Terminator for the list
-  Info[9].Type          = EfiMaxMemoryType;
-  Info[9].NumberOfPages = 0;
+  Info[5].Type          = EfiMaxMemoryType;
+  Info[5].NumberOfPages = 0;
+  // MU_CHANGE [END] - Remove non-RT types from Mem Type Info Settings
 
   BuildGuidDataHob (&gEfiMemoryTypeInformationGuid, &Info, sizeof (Info));
 }


### PR DESCRIPTION
## Description

Remove non-RT types from Mem Type Info Settings

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed that the following error message from mu_basecore\MdeModulePkg\Library\MemoryTypeInfoSecVarCheckLib doesn't occur.
  //
  // Check DataSize.
  //
  if (DataSize != EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE) {
    DEBUG ((
      DEBUG_ERROR,
      "ERROR: %a() - DataSize = 0x%x Expected = 0x%x. Check actual memory types against expected memory types.\n",
      __FUNCTION__,
      DataSize,
      EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE
      ));
    return EFI_SECURITY_VIOLATION;
  }

## Integration Instructions

N/A