### PR TITLE
[Cherry-Pick] Tcg2Smm: Added support for Standalone Mm [RB&FF]

### DIFF
--- a/SecurityPkg/Include/Guid/Tcg2AcpiCommunicateBuffer.h
+++ b/SecurityPkg/Include/Guid/Tcg2AcpiCommunicateBuffer.h
@@ -1,0 +1,33 @@
+/** @file
+  This Tcg2 Acpi Communicate Buffer HOB is used to store the address
+  of a buffer reserved for Tcg2Acpi driver. The buffer will be used to
+  retrive information from standalone mm environment.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef TCG2_ACPI_COMMUNICATE_BUFFER_H_
+#define TCG2_ACPI_COMMUNICATE_BUFFER_H_
+
+#define TCG2_ACPI_COMMUNICATE_BUFFER_HOB_REVISION  1
+
+#define TCG2_ACPI_COMMUNICATE_BUFFER_GUID \
+  { \
+    0xcefea14f, 0x9f1a, 0x4774, {0x8d, 0x18, 0x79, 0x93, 0x8d, 0x48, 0xfe, 0x7d}  \
+  }
+
+typedef struct {
+  ///
+  /// Base address of the buffer reserved for Tcg2Acpi driver.
+  /// Tcg2Acpi will use it to exchange information with Tcg2StandaloneMm.
+  ///
+  EFI_PHYSICAL_ADDRESS    Tcg2AcpiCommunicateBuffer;
+  UINT64                  Pages;
+} TCG2_ACPI_COMMUNICATE_BUFFER;
+
+extern EFI_GUID  gEdkiiTcg2AcpiCommunicateBufferHobGuid;
+
+#endif

--- a/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/MmTcg2PhysicalPresenceLibCommon.c
+++ b/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/MmTcg2PhysicalPresenceLibCommon.c
@@ -10,24 +10,12 @@
   Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction() and Tcg2PhysicalPresenceLibGetUserConfirmationStatusFunction()
   will receive untrusted input and do validation.
 
-Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <PiMm.h>
-
-#include <Guid/Tcg2PhysicalPresenceData.h>
-
-#include <Protocol/SmmVariable.h>
-
-#include <Library/BaseLib.h>
-#include <Library/DebugLib.h>
-#include <Library/BaseMemoryLib.h>
-#include <Library/Tcg2PpVendorLib.h>
-#include <Library/MmServicesTableLib.h>
-
-#define     PP_INF_VERSION_1_2  "1.2"
+#include "MmTcg2PhysicalPresenceLibCommon.h"
 
 EFI_SMM_VARIABLE_PROTOCOL  *mTcg2PpSmmVariable;
 BOOLEAN                    mIsTcg2PPVerLowerThan_1_3 = FALSE;
@@ -407,9 +395,7 @@ Tcg2PhysicalPresenceLibCommonConstructor (
 {
   EFI_STATUS  Status;
 
-  if (AsciiStrnCmp (PP_INF_VERSION_1_2, (CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer), sizeof (PP_INF_VERSION_1_2) - 1) >= 0) {
-    mIsTcg2PPVerLowerThan_1_3 = TRUE;
-  }
+  mIsTcg2PPVerLowerThan_1_3 = IsTcg2PPVerLowerThan_1_3 ();
 
   //
   // Locate SmmVariableProtocol.

--- a/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/MmTcg2PhysicalPresenceLibCommon.h
+++ b/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/MmTcg2PhysicalPresenceLibCommon.h
@@ -10,13 +10,25 @@
   Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction() and Tcg2PhysicalPresenceLibGetUserConfirmationStatusFunction()
   will receive untrusted input and do validation.
 
-Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef _MM_TCG2_PHYSICAL_PRESENCE_LIB_COMMON_H_
 #define _MM_TCG2_PHYSICAL_PRESENCE_LIB_COMMON_H_
+
+#include <Guid/Tcg2PhysicalPresenceData.h>
+
+#include <Protocol/SmmVariable.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/Tcg2PpVendorLib.h>
+#include <Library/MmServicesTableLib.h>
+
+#define   PP_INF_VERSION_1_2  "1.2"
 
 /**
   The constructor function locates MmVariable protocol.
@@ -28,6 +40,17 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 EFI_STATUS
 Tcg2PhysicalPresenceLibCommonConstructor (
+  VOID
+  );
+
+/**
+  Check if Tcg2 PP version is lower than PP_INF_VERSION_1_3.
+
+  @retval TRUE    Tcg2 PP version is lower than PP_INF_VERSION_1_3.
+  @retval Other   Tcg2 PP version is not lower than PP_INF_VERSION_1_3.
+**/
+BOOLEAN
+IsTcg2PPVerLowerThan_1_3 (
   VOID
   );
 

--- a/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.c
@@ -10,7 +10,7 @@
   Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction() and Tcg2PhysicalPresenceLibGetUserConfirmationStatusFunction()
   will receive untrusted input and do validation.
 
-Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -38,4 +38,18 @@ Tcg2PhysicalPresenceLibTraditionalConstructor (
   )
 {
   return Tcg2PhysicalPresenceLibCommonConstructor ();
+}
+
+/**
+  Check if Tcg2 PP version is lower than PP_INF_VERSION_1_3.
+
+  @retval TRUE    Tcg2 PP version is lower than PP_INF_VERSION_1_3.
+  @retval Other   Tcg2 PP version is not lower than PP_INF_VERSION_1_3.
+**/
+BOOLEAN
+IsTcg2PPVerLowerThan_1_3 (
+  VOID
+  )
+{
+  return (BOOLEAN)(AsciiStrnCmp (PP_INF_VERSION_1_2, (CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer), sizeof (PP_INF_VERSION_1_2) - 1) >= 0);
 }

--- a/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/StandaloneMmTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/StandaloneMmTcg2PhysicalPresenceLib.c
@@ -10,13 +10,15 @@
   Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction() and Tcg2PhysicalPresenceLibGetUserConfirmationStatusFunction()
   will receive untrusted input and do validation.
 
-Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <PiMm.h>
+
+#include <Library/HobLib.h>
 
 #include "MmTcg2PhysicalPresenceLibCommon.h"
 
@@ -39,4 +41,27 @@ Tcg2PhysicalPresenceLibStandaloneMmConstructor (
   )
 {
   return Tcg2PhysicalPresenceLibCommonConstructor ();
+}
+
+/**
+  Check if Tcg2 PP version is lower than PP_INF_VERSION_1_3.
+
+  @retval TRUE    Tcg2 PP version is lower than PP_INF_VERSION_1_3.
+  @retval Other   Tcg2 PP version is not lower than PP_INF_VERSION_1_3.
+**/
+BOOLEAN
+IsTcg2PPVerLowerThan_1_3 (
+  VOID
+  )
+{
+  VOID  *GuidHob;
+
+  GuidHob = GetFirstGuidHob (&gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid);
+  ASSERT (GuidHob != NULL);
+
+  if (AsciiStrnCmp (PP_INF_VERSION_1_2, (CHAR8 *)GET_GUID_HOB_DATA (GuidHob), sizeof (PP_INF_VERSION_1_2) - 1) >= 0) {
+    return TRUE;
+  }
+
+  return FALSE;
 }

--- a/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/StandaloneMmTcg2PhysicalPresenceLib.inf
+++ b/SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/StandaloneMmTcg2PhysicalPresenceLib.inf
@@ -7,7 +7,7 @@
 #  This driver will have external input - variable.
 #  This external input must be validated carefully to avoid security issue.
 #
-# Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,18 +44,19 @@
   Tcg2PpVendorLib
   MmServicesTableLib
   BaseMemoryLib
+  HobLib
 
 [Guids]
   ## SOMETIMES_PRODUCES ## Variable:L"PhysicalPresence"
   ## SOMETIMES_CONSUMES ## Variable:L"PhysicalPresence"
   ## SOMETIMES_CONSUMES ## Variable:L"PhysicalPresenceFlags"
   gEfiTcg2PhysicalPresenceGuid
+  gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid
 
 [Protocols]
   gEfiSmmVariableProtocolGuid                                       ## CONSUMES
 
 [Pcd]
-  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer  ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2PhysicalPresenceFlags        ## SOMETIMES_CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdDisallowPPIPersistentClearPermissions  ## CONSUMES # MU_CHANGE 108842
 

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -274,6 +274,10 @@
   ## The GUIDed HOB contains the same value as PcdGetPtr (PcdTpmInstanceGuid).
   gEdkiiTpmInstanceHobGuid           = { 0x4551b023, 0xba46, 0x4584, { 0x81, 0xcd, 0x4d, 0xe8, 0x61, 0xa7, 0x28, 0xbe } }
 
+  ## GUID used to tag the HOB indicating the Version of Physical Presence interface.
+  ## The GUIDed HOB contains the same value as PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer).
+  gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid = { 0x3979411a, 0x4e6d, 0x47e4, { 0x94, 0x4b, 0x0e, 0xcc, 0x6c, 0xf6, 0xc0, 0xcd } }
+
 [Protocols]
   ## MU_CHANGE - START - Add a new protocol to support Log-only events.
   # Include/Protocol/MuTcg2Protocol.h

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -278,6 +278,9 @@
   ## The GUIDed HOB contains the same value as PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer).
   gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid = { 0x3979411a, 0x4e6d, 0x47e4, { 0x94, 0x4b, 0x0e, 0xcc, 0x6c, 0xf6, 0xc0, 0xcd } }
 
+  ## Include/Guid/Tcg2AcpiCommunicateBuffer.h
+  gEdkiiTcg2AcpiCommunicateBufferHobGuid = { 0xcefea14f, 0x9f1a, 0x4774, { 0x8d, 0x18, 0x79, 0x93, 0x8d, 0x48, 0xfe, 0x7d } }
+
 [Protocols]
   ## MU_CHANGE - START - Add a new protocol to support Log-only events.
   # Include/Protocol/MuTcg2Protocol.h

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -270,6 +270,10 @@
   ## GUID used to generate Spdm Uid
   gEfiDeviceSecuritySpdmUidGuid = {0xe37b5665, 0x5ef9, 0x4e7e, {0xb4, 0x91, 0xd6, 0x78, 0xab, 0xff, 0xfb, 0xcb }}
 
+  ## GUID used to tag the HOB indicating the TPM instance.
+  ## The GUIDed HOB contains the same value as PcdGetPtr (PcdTpmInstanceGuid).
+  gEdkiiTpmInstanceHobGuid           = { 0x4551b023, 0xba46, 0x4584, { 0x81, 0xcd, 0x4d, 0xe8, 0x61, 0xa7, 0x28, 0xbe } }
+
 [Protocols]
   ## MU_CHANGE - START - Add a new protocol to support Log-only events.
   # Include/Protocol/MuTcg2Protocol.h

--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
@@ -9,7 +9,7 @@
   This driver will have external input - variable and ACPINvs data in SMM mode.
   This external input must be validated carefully to avoid security issue.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/TpmInstance.h>
 #include <Guid/TpmNvsMm.h>
 #include <Guid/PiSmmCommunicationRegionTable.h>
+#include <Guid/Tcg2AcpiCommunicateBuffer.h>
 
 #include <Protocol/AcpiTable.h>
 #include <Protocol/Tcg2Protocol.h>
@@ -38,7 +39,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/Tpm2CommandLib.h>
 #include <Library/UefiLib.h>
-#include <Library/MmUnblockMemoryLib.h>
+#include <Library/HobLib.h>
 
 //
 // Physical Presence Interface Version supported by Platform
@@ -116,7 +117,7 @@ TCG_NVS  *mTcgNvs;
   @param[in]      Name           The name string to find in TPM table.
   @param[in]      Size           The size of the region to find.
 
-  @return                        The allocated address for the found region.
+  @return                        The Acpi Communicate Buffer for the found region.
 
 **/
 VOID *
@@ -126,9 +127,10 @@ AssignOpRegion (
   UINT16                       Size
   )
 {
-  EFI_STATUS            Status;
-  AML_OP_REGION_32_8    *OpRegion;
-  EFI_PHYSICAL_ADDRESS  MemoryAddress;
+  AML_OP_REGION_32_8            *OpRegion;
+  EFI_PHYSICAL_ADDRESS          MemoryAddress;
+  EFI_HOB_GUID_TYPE             *GuidHob;
+  TCG2_ACPI_COMMUNICATE_BUFFER  *Tcg2AcpiCommunicateBufferHob;
 
   MemoryAddress = SIZE_4GB - 1;
 
@@ -144,16 +146,16 @@ AssignOpRegion (
         (OpRegion->DWordPrefix == AML_DWORD_PREFIX) &&
         (OpRegion->BytePrefix  == AML_BYTE_PREFIX))
     {
-      Status = gBS->AllocatePages (AllocateMaxAddress, EfiACPIMemoryNVS, EFI_SIZE_TO_PAGES (Size), &MemoryAddress);
-      ASSERT_EFI_ERROR (Status);
+      GuidHob = GetFirstGuidHob (&gEdkiiTcg2AcpiCommunicateBufferHobGuid);
+      ASSERT (GuidHob != NULL);
+      Tcg2AcpiCommunicateBufferHob = GET_GUID_HOB_DATA (GuidHob);
+      MemoryAddress                = Tcg2AcpiCommunicateBufferHob->Tcg2AcpiCommunicateBuffer;
+      ASSERT (MemoryAddress != 0);
+      ASSERT (EFI_PAGES_TO_SIZE (Tcg2AcpiCommunicateBufferHob->Pages) >= Size);
+
       ZeroMem ((VOID *)(UINTN)MemoryAddress, Size);
       OpRegion->RegionOffset = (UINT32)(UINTN)MemoryAddress;
       OpRegion->RegionLen    = (UINT8)Size;
-      // Request to unblock this region from MM core
-      Status = MmUnblockMemoryRequest (MemoryAddress, EFI_SIZE_TO_PAGES (Size));
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        ASSERT_EFI_ERROR (Status);
-      }
 
       break;
     }

--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.inf
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.inf
@@ -22,7 +22,7 @@
 #  This driver will have external input - variable and ACPINvs data in SMM mode.
 #  This external input must be validated carefully to avoid security issue.
 #
-# Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -57,12 +57,13 @@
   Tpm2CommandLib
   Tcg2PhysicalPresenceLib
   PcdLib
-  MmUnblockMemoryLib
+  HobLib
 
 [Guids]
   gEfiTpmDeviceInstanceTpm20DtpmGuid                            ## PRODUCES           ## GUID       # TPM device identifier
   gTpmNvsMmGuid                                                 ## CONSUMES
   gEdkiiPiSmmCommunicationRegionTableGuid                       ## CONSUMES
+  gEdkiiTcg2AcpiCommunicateBufferHobGuid
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                                     ## CONSUMES

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -4,7 +4,7 @@
 #  This module initializes TPM device type based on variable and detection.
 #  NOTE: This module is only for reference only, each platform should have its own setup page.
 #
-# Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -46,6 +46,7 @@
   TimerLib
   Tpm12CommandLib
   Tpm12DeviceLib
+  HobLib
 
 [Guids]
   ## SOMETIMES_CONSUMES ## Variable:L"TCG2_CONFIGURATION"
@@ -53,6 +54,8 @@
   gTcg2ConfigFormSetGuid
   gEfiTpmDeviceSelectedGuid           ## PRODUCES             ## GUID    # Used as a PPI GUID
   gEfiTpmDeviceInstanceNoneGuid       ## SOMETIMES_CONSUMES   ## GUID    # TPM device identifier
+  gEdkiiTpmInstanceHobGuid
+  gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid
 
 [Ppis]
   gEfiPeiReadOnlyVariable2PpiGuid     ## CONSUMES
@@ -62,6 +65,7 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                 ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInitializationPolicy         ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmAutoDetection                ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer
 
 [Depex]
   gEfiPeiMasterBootModePpiGuid AND

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -47,6 +47,7 @@
   Tpm12CommandLib
   Tpm12DeviceLib
   HobLib
+  MmUnblockMemoryLib
 
 [Guids]
   ## SOMETIMES_CONSUMES ## Variable:L"TCG2_CONFIGURATION"
@@ -56,10 +57,12 @@
   gEfiTpmDeviceInstanceNoneGuid       ## SOMETIMES_CONSUMES   ## GUID    # TPM device identifier
   gEdkiiTpmInstanceHobGuid
   gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid
+  gEdkiiTcg2AcpiCommunicateBufferHobGuid
 
 [Ppis]
   gEfiPeiReadOnlyVariable2PpiGuid     ## CONSUMES
   gPeiTpmInitializationDonePpiGuid    ## SOMETIMES_PRODUCES
+  gEfiPeiMemoryDiscoveredPpiGuid
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                 ## PRODUCES

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -1,7 +1,7 @@
 /** @file
   The module entry point for Tcg2 configuration module.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/PcdLib.h>
+#include <Library/HobLib.h>
 
 #include <Ppi/ReadOnlyVariable2.h>
 #include <Ppi/TpmInitialized.h>
@@ -73,6 +74,7 @@ Tcg2ConfigPeimEntryPoint (
   TCG2_CONFIGURATION               Tcg2Configuration;
   UINTN                            Index;
   UINT8                            TpmDevice;
+  VOID                             *Hob;
 
   Status = PeiServicesLocatePpi (&gEfiPeiReadOnlyVariable2PpiGuid, 0, NULL, (VOID **)&VariablePpi);
   ASSERT_EFI_ERROR (Status);
@@ -132,6 +134,26 @@ Tcg2ConfigPeimEntryPoint (
       break;
     }
   }
+
+  //
+  // Build Hob for PcdTpmInstanceGuid
+  //
+  Hob = BuildGuidDataHob (
+          &gEdkiiTpmInstanceHobGuid,
+          PcdGetPtr (PcdTpmInstanceGuid),
+          sizeof (EFI_GUID)
+          );
+  ASSERT (Hob != NULL);
+
+  //
+  // Build Hob for PcdTcgPhysicalPresenceInterfaceVer
+  //
+  Hob = BuildGuidDataHob (
+          &gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid,
+          PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
+          AsciiStrSize ((CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer))
+          );
+  ASSERT (Hob != NULL);
 
   //
   // Selection done

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -9,7 +9,7 @@
 
   PhysicalPresenceCallback() and MemoryClearCallback() will receive untrusted input and do some check.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -298,7 +298,7 @@ InitializeTcgCommon (
   EFI_HANDLE                     McSwHandle;
   EFI_HANDLE                     NotifyHandle;
 
-  if (!CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm20DtpmGuid)) {
+  if (!IsTpm20Dtpm ()) {
     DEBUG ((DEBUG_ERROR, "No TPM2 DTPM instance required!\n"));
     return EFI_UNSUPPORTED;
   }

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.h
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.h
@@ -1,7 +1,7 @@
 /** @file
   The header file for Tcg2 SMM driver.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -97,6 +97,17 @@ IsCommBufferValid (
 **/
 EFI_STATUS
 InitializeTcgCommon (
+  VOID
+  );
+
+/**
+  This function checks if the required DTPM instance is TPM 2.0.
+
+  @retval TRUE  The required DTPM instance is equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+  @retval FALSE The required DTPM instance is not equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+**/
+BOOLEAN
+IsTpm20Dtpm (
   VOID
   );
 

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.c
@@ -9,7 +9,7 @@
 
   PhysicalPresenceCallback() and MemoryClearCallback() will receive untrusted input and do some check.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "Tcg2Smm.h"
 #include <Library/StandaloneMmMemLib.h>
+#include <Library/HobLib.h>
 
 /**
   Notify the system that the SMM variable driver is ready.
@@ -64,6 +65,33 @@ IsCommBufferValid (
   )
 {
   return MmCommBufferValid (Buffer, Length);
+}
+
+/**
+  This function checks if the required DTPM instance is TPM 2.0.
+
+  @retval TRUE  The required DTPM instance is equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+  @retval FALSE The required DTPM instance is not equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+**/
+BOOLEAN
+IsTpm20Dtpm (
+  VOID
+  )
+{
+  VOID  *GuidHob;
+
+  GuidHob = GetFirstGuidHob (&gEdkiiTpmInstanceHobGuid);
+  if (GuidHob != NULL) {
+    if (CompareGuid ((EFI_GUID *)GET_GUID_HOB_DATA (GuidHob), &gEfiTpmDeviceInstanceTpm20DtpmGuid)) {
+      return TRUE;
+    }
+
+    DEBUG ((DEBUG_ERROR, "No TPM2 DTPM instance required! - %g\n", (EFI_GUID *)GET_GUID_HOB_DATA (GuidHob)));
+  } else {
+    DEBUG ((DEBUG_ERROR, "No gEdkiiTpmInstanceHobGuid!\n"));
+  }
+
+  return FALSE;
 }
 
 /**

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.inf
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2StandaloneMm.inf
@@ -20,7 +20,7 @@
 #  This driver will have external input - variable and ACPINvs data in SMM mode.
 #  This external input must be validated carefully to avoid security issue.
 #
-# Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -55,6 +55,7 @@
   Tcg2PhysicalPresenceLib
   PcdLib
   MemLib
+  HobLib
 
 [Guids]
   ## SOMETIMES_PRODUCES ## Variable:L"MemoryOverwriteRequestControl"
@@ -63,14 +64,12 @@
 
   gEfiTpmDeviceInstanceTpm20DtpmGuid                            ## PRODUCES           ## GUID       # TPM device identifier
   gTpmNvsMmGuid                                                 ## CONSUMES
+  gEdkiiTpmInstanceHobGuid
 
 [Protocols]
   gEfiSmmSwDispatch2ProtocolGuid                                ## CONSUMES
   gEfiSmmVariableProtocolGuid                                   ## CONSUMES
   gEfiMmReadyToLockProtocolGuid                                 ## CONSUMES
-
-[Pcd]
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid              ## CONSUMES
 
 [Depex]
   gEfiSmmSwDispatch2ProtocolGuid AND

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2TraditionalMm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2TraditionalMm.c
@@ -9,7 +9,7 @@
 
   PhysicalPresenceCallback() and MemoryClearCallback() will receive untrusted input and do some check.
 
-Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -75,6 +75,20 @@ IsCommBufferValid (
   )
 {
   return SmmIsBufferOutsideSmmValid (Buffer, Length);
+}
+
+/**
+ This function checks if the required DTPM instance is TPM 2.0.
+
+ @retval TRUE  The required DTPM instance is equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+ @retval FALSE The required DTPM instance is not equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+**/
+BOOLEAN
+IsTpm20Dtpm (
+  VOID
+  )
+{
+  return CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm20DtpmGuid);
 }
 
 /**


### PR DESCRIPTION
## Description

Cherry-Picking https://github.com/tianocore/edk2/pull/5728 from edk2.

This change added Standalone MM instance of Tcg2. The notify function for
Standalone MM instance is left empty.

A dependency DXE driver with a Depex of gEfiMmCommunication2ProtocolGuid
was created to indicate the readiness of Standalone MM Tcg2 driver.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Platform using standalone mm required these changes for Tcg2 MM support to corectly work.

## Integration Instructions

There should be no changes for existing platforms using smm.