### PR TITLE
[FF-A][TPM] Add the Internal TPM CRB Address to the .dec

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
@@ -23,7 +23,7 @@
   FILE_GUID                      = E54A3327-A345-4068-8842-70AC0D519855
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = Tpm2DeviceLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  LIBRARY_CLASS                  = Tpm2DeviceLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER MM_CORE_STANDALONE
   CONSTRUCTOR                    = Tpm2DeviceLibConstructor
 #
 # The following information is for reference only and not required by the build tools.

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
@@ -23,7 +23,7 @@
   FILE_GUID                      = E54A3327-A345-4068-8842-70AC0D519855
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = Tpm2DeviceLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER MM_CORE_STANDALONE
+  LIBRARY_CLASS                  = Tpm2DeviceLib|PEIM DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER
   CONSTRUCTOR                    = Tpm2DeviceLibConstructor
 #
 # The following information is for reference only and not required by the build tools.

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -507,6 +507,10 @@
   # @Prompt TPM device base address.
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xFED40000|UINT64|0x00010012
 
+    ## This PCD indicates internal TPM base address.<BR><BR>
+  # @Prompt TPM device base address.
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInternalBaseAddress|0x10000010000|UINT64|0x0001002A
+
   ## This PCD indicates TPM max address.<BR><BR>
   # @Prompt TPM device max address.
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress|0xFED44FFF|UINT64|0x00010029


### PR DESCRIPTION
## Description

The TPM Service running in the secure partition will need to know the address of the internal CRB buffer for copying TPM data to/from the actual MMIO CRB. Added the address as a PCD in the .dec for SecurityPkg.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Verified by enabling TPM support through the TPM defines and running the TPM service.

## Integration Instructions

N/A
