### PR TITLE
Add Partition ID PCD

### DIFF
--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -424,14 +424,6 @@
   # FALSE -The Platform will not measure those events
   gEfiSecurityPkgTokenSpaceGuid.TcgMeasureBootStringsInPcr4|TRUE|BOOLEAN|0x0000000B
 
-  ## MU_CHANGE: Add a PCD to determine partition ID of TPM Service.
-  #
-  # Define the partition ID for TPM Service.
-  # Default PcdTpmServiceFfaPartitionId = 0x0, which should never be set to by
-  # the FF-A framework.
-  #
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmServiceFfaPartitionId|0|UINT16|0x0000000C
-
 [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## Indicates whether TPM physical presence is locked during platform initialization.
   #  Once it is locked, it can not be unlocked for TPM life time.<BR><BR>
@@ -666,6 +658,14 @@
 
   ## This PCD records LASA field in CC EVENTLOG ACPI table.
   gEfiSecurityPkgTokenSpaceGuid.PcdCcEventlogAcpiTableLasa|0|UINT64|0x00010026
+
+  ## MU_CHANGE: Add a PCD to determine partition ID of TPM Service.
+  #
+  # Define the partition ID for TPM Service.
+  # Default PcdTpmServiceFfaPartitionId = 0x0, which should never be set to by
+  # the FF-A framework.
+  #
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmServiceFfaPartitionId|0|UINT16|0x0001002B
 
 [PcdsFeatureFlag]
   ## Indicates if the platform requires PK to be self-signed when setting the PK in setup mode.

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -424,6 +424,14 @@
   # FALSE -The Platform will not measure those events
   gEfiSecurityPkgTokenSpaceGuid.TcgMeasureBootStringsInPcr4|TRUE|BOOLEAN|0x0000000B
 
+  ## MU_CHANGE: Add a PCD to determine partition ID of TPM Service.
+  #
+  # Define the partition ID for TPM Service.
+  # Default PcdTpmServiceFfaPartitionId = 0x0, which should never be set to by
+  # the FF-A framework.
+  #
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmServiceFfaPartitionId|0|UINT16|0x0000000C
+
 [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## Indicates whether TPM physical presence is locked during platform initialization.
   #  Once it is locked, it can not be unlocked for TPM life time.<BR><BR>

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -658,8 +658,10 @@ PublishTpm2 (
   }
 
   InterfaceType = PcdGet8 (PcdActiveTpmInterfaceType);
-  PartitionId   = PcdGet16 (PcdTpmServiceFfaPartitionId);
   DEBUG ((DEBUG_INFO, "Tpm Active Interface Type %d\n", InterfaceType));
+
+  PartitionId   = PcdGet16 (PcdTpmServiceFfaPartitionId);
+  ASSERT (PartitionId != 0);
   if (InterfaceType == Tpm2PtpInterfaceCrb) {
     mTpm2AcpiTemplate.StartMethod                   = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE_WITH_FFA;
     mTpm2AcpiTemplate.AddressOfControlArea          = PcdGet64 (PcdTpmBaseAddress) + 0x40;

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -623,6 +623,7 @@ PublishTpm2 (
   UINT64                      OemTableId;
   EFI_TPM2_ACPI_CONTROL_AREA  *ControlArea;
   TPM2_PTP_INTERFACE_TYPE     InterfaceType;
+  UINT64                      PartitionId;
 
   // Allow a platform to drop TCG ACPI measurements until we have a chance to make them more
   // consistent and functional.
@@ -657,14 +658,15 @@ PublishTpm2 (
   }
 
   InterfaceType = PcdGet8 (PcdActiveTpmInterfaceType);
+  PartitionId   = PcdGet16 (PcdTpmServiceFfaPartitionId);
   DEBUG ((DEBUG_INFO, "Tpm Active Interface Type %d\n", InterfaceType));
   if (InterfaceType == Tpm2PtpInterfaceCrb) {
     mTpm2AcpiTemplate.StartMethod                   = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE_WITH_FFA;
     mTpm2AcpiTemplate.AddressOfControlArea          = PcdGet64 (PcdTpmBaseAddress) + 0x40;
     mTpm2AcpiTemplate.PlatformSpecificParameters[0] = 0x00;   // Notifications Not Supported
     mTpm2AcpiTemplate.PlatformSpecificParameters[1] = 0x00;   // CRB 4KiB size, Not Cacheable
-    mTpm2AcpiTemplate.PlatformSpecificParameters[2] = 0x80;   // HI Byte of Partition ID
-    mTpm2AcpiTemplate.PlatformSpecificParameters[3] = 0x02;   // LO Byte of Partition ID
+    mTpm2AcpiTemplate.PlatformSpecificParameters[2] = (PartitionId >> 8) & MAX_UINT8; // HI Byte of Partition ID
+    mTpm2AcpiTemplate.PlatformSpecificParameters[3] = (PartitionId) & MAX_UINT8;      // LO Byte of Partition ID
     ControlArea                                     = (EFI_TPM2_ACPI_CONTROL_AREA *)(UINTN)mTpm2AcpiTemplate.AddressOfControlArea;
     ControlArea->CommandSize                        = 0xF80;
     ControlArea->ResponseSize                       = 0xF80;

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -660,13 +660,13 @@ PublishTpm2 (
   InterfaceType = PcdGet8 (PcdActiveTpmInterfaceType);
   DEBUG ((DEBUG_INFO, "Tpm Active Interface Type %d\n", InterfaceType));
 
-  PartitionId   = PcdGet16 (PcdTpmServiceFfaPartitionId);
+  PartitionId = PcdGet16 (PcdTpmServiceFfaPartitionId);
   ASSERT (PartitionId != 0);
   if (InterfaceType == Tpm2PtpInterfaceCrb) {
     mTpm2AcpiTemplate.StartMethod                   = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE_WITH_FFA;
     mTpm2AcpiTemplate.AddressOfControlArea          = PcdGet64 (PcdTpmBaseAddress) + 0x40;
-    mTpm2AcpiTemplate.PlatformSpecificParameters[0] = 0x00;   // Notifications Not Supported
-    mTpm2AcpiTemplate.PlatformSpecificParameters[1] = 0x00;   // CRB 4KiB size, Not Cacheable
+    mTpm2AcpiTemplate.PlatformSpecificParameters[0] = 0x00;                           // Notifications Not Supported
+    mTpm2AcpiTemplate.PlatformSpecificParameters[1] = 0x00;                           // CRB 4KiB size, Not Cacheable
     mTpm2AcpiTemplate.PlatformSpecificParameters[2] = (PartitionId >> 8) & MAX_UINT8; // HI Byte of Partition ID
     mTpm2AcpiTemplate.PlatformSpecificParameters[3] = (PartitionId) & MAX_UINT8;      // LO Byte of Partition ID
     ControlArea                                     = (EFI_TPM2_ACPI_CONTROL_AREA *)(UINTN)mTpm2AcpiTemplate.AddressOfControlArea;

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
@@ -65,6 +65,7 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdSkipTcgSmmAcpiMeasurements       ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLaml                ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLasa                ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmServiceFfaPartitionId         ## CONSUMES
 
 [FixedPcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress                   ## CONSUMES


### PR DESCRIPTION
## Description

This change add a partition ID PCD and consume it in the ACPI table production step. Platform should set this PCD value before ACPI table being created.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>