### PR TITLE
[FF-A][TPM] Added TPM CRB Size PCD

### DIFF
--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -509,11 +509,15 @@
 
     ## This PCD indicates internal TPM base address.<BR><BR>
   # @Prompt TPM device base address.
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInternalBaseAddress|0x10000010000|UINT64|0x0001002A
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInternalBaseAddress|0x10000200000|UINT64|0x0001002A
 
   ## This PCD indicates TPM max address.<BR><BR>
   # @Prompt TPM device max address.
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress|0xFED44FFF|UINT64|0x00010029
+
+  ## This PCD indicates the size of the TPM CRB region.<BR><BR>
+  # @Prompt TPM device CRB region size.
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmCrbRegionSize|0x5000|UINT32|0x0001002C
 
   ## This PCR means the OEM configured number of PCR banks.
   #  0 means dynamic get from supported HASH algorithm

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -625,6 +625,8 @@ PublishTpm2 (
   TPM2_PTP_INTERFACE_TYPE     InterfaceType;
   UINT64                      PartitionId;
 
+  STATIC_ASSERT ((FixedPcdGet64 (PcdTpmMaxAddress) - FixedPcdGet64 (PcdTpmBaseAddress)) == (FixedPcdGet32 (PcdTpmCrbRegionSize) - 1), "TPM CRB region size mismatch");
+
   // Allow a platform to drop TCG ACPI measurements until we have a chance to make them more
   // consistent and functional.
   if (!FixedPcdGetBool (PcdSkipTcgSmmAcpiMeasurements)) {

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
@@ -70,6 +70,7 @@
 [FixedPcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress                   ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmMaxAddress                    ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmCrbRegionSize                 ## CONSUMES
 
 [Depex]
   gEfiAcpiTableProtocolGuid AND

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tpm2Ffa.asl
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tpm2Ffa.asl
@@ -24,7 +24,7 @@ DefinitionBlock (
       //
       // Operational region for TPM access
       //
-      OperationRegion (TPMR, SystemMemory, FixedPcdGet64 (PcdTpmBaseAddress), 0x5000)
+      OperationRegion (TPMR, SystemMemory, FixedPcdGet64 (PcdTpmBaseAddress), FixedPcdGet32 (PcdTpmCrbRegionSize))
       Field (TPMR, AnyAcc, NoLock, Preserve)
       {
         ACC0, 8,  // TPM_ACCESS_0
@@ -56,7 +56,7 @@ DefinitionBlock (
             FixedPcdGet64 (PcdTpmBaseAddress), 
             FixedPcdGet64 (PcdTpmMaxAddress), 
             0x0, 
-            0x5000)
+            FixedPcdGet32 (PcdTpmCrbRegionSize))
         })
         Return (RBUF)
       }


### PR DESCRIPTION
## Description

Added TPM CRB Size PCD for .asl code. This replaces a hard coded value which allows for flexible CRB lengths. Added an ASSERT to make sure MAX-BASE==(SIZE-1). Fixed the internal base address value.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Ran the build with TPM enabled.

## Integration Instructions

N/A
