### PR TITLE
Implementing BuildResourceDescriptorV2 for PrePiHobLib

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -195,7 +195,7 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Branch": "release/202405"
+                "Branch": "dev/202405"
             }
         ]
 

--- a/EmbeddedPkg/Library/PrePiHobLib/Hob.c
+++ b/EmbeddedPkg/Library/PrePiHobLib/Hob.c
@@ -177,6 +177,50 @@ BuildResourceDescriptorHob (
   Hob->ResourceLength    = NumberOfBytes;
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  EFI_HOB_RESOURCE_DESCRIPTOR_V2  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR_V2));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->V1.ResourceType      = ResourceType;
+  Hob->V1.ResourceAttribute = ResourceAttribute;
+  Hob->V1.PhysicalStart     = PhysicalStart;
+  Hob->V1.ResourceLength    = NumberOfBytes;
+  Hob->Attributes           = EfiMemoryAttributes;
+}
+
+// MU_CHANGE End
+
 VOID
 EFIAPI
 BuildFvHobs (

--- a/EmbeddedPkg/Library/PrePiHobLib/Hob.c
+++ b/EmbeddedPkg/Library/PrePiHobLib/Hob.c
@@ -206,7 +206,7 @@ BuildResourceDescriptorV2 (
 {
   EFI_HOB_RESOURCE_DESCRIPTOR_V2  *Hob;
 
-  Hob = CreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR_V2));
+  Hob = CreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR_V2));
   ASSERT (Hob != NULL);
   if (Hob == NULL) {
     return;


### PR DESCRIPTION
## Description

This change adds the implementation of `BuildResourceDescriptorV2` in PrePiHobLib.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA and booted to Windows.

## Integration Instructions

N/A
