### PR TITLE
PRM support for non-existent MMIO ranges

### DIFF
--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -100,18 +100,22 @@ SetRuntimeMemoryRangeAttributes (
 
     Status2 = EFI_NOT_FOUND;
     Status  = gDS->GetMemorySpaceDescriptor (RuntimeMmioRanges->Range[Index].PhysicalBaseAddress, &Descriptor);
-    if (!EFI_ERROR (Status) &&
+    if (!EFI_ERROR (Status) && (Descriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) 
+    {
+      // The MMIO range is visible but has not been added to the memory space treat the region as not found.
+      Status = EFI_NOT_FOUND;
+    } else if (!EFI_ERROR (Status) &&
         (
          ((Descriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo) && (Descriptor.GcdMemoryType != EfiGcdMemoryTypeReserved)) ||
          ((Descriptor.Length & EFI_PAGE_MASK) != 0)
         )
-        )
+      )
     {
       Status2 =  gDS->RemoveMemorySpace (
                         RuntimeMmioRanges->Range[Index].PhysicalBaseAddress,
                         Descriptor.Length
                         );
-    }
+    } 
 
     if ((Status == EFI_NOT_FOUND) || !EFI_ERROR (Status2)) {
       Status = gDS->AddMemorySpace (

--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -100,16 +100,15 @@ SetRuntimeMemoryRangeAttributes (
 
     Status2 = EFI_NOT_FOUND;
     Status  = gDS->GetMemorySpaceDescriptor (RuntimeMmioRanges->Range[Index].PhysicalBaseAddress, &Descriptor);
-    if (!EFI_ERROR (Status) && (Descriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) 
-    {
+    if (!EFI_ERROR (Status) && (Descriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) {
       // The MMIO range is visible but has not been added to the memory space treat the region as not found.
       Status = EFI_NOT_FOUND;
     } else if (!EFI_ERROR (Status) &&
-    (
-      ((Descriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo) && (Descriptor.GcdMemoryType != EfiGcdMemoryTypeReserved)) ||
-      ((Descriptor.Length & EFI_PAGE_MASK) != 0)
-     )
-     )
+               (
+                ((Descriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo) && (Descriptor.GcdMemoryType != EfiGcdMemoryTypeReserved)) ||
+                ((Descriptor.Length & EFI_PAGE_MASK) != 0)
+               )
+               )
     {
       Status2 =  gDS->RemoveMemorySpace (
                         RuntimeMmioRanges->Range[Index].PhysicalBaseAddress,

--- a/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
+++ b/PrmPkg/PrmConfigDxe/PrmConfigDxe.c
@@ -105,17 +105,17 @@ SetRuntimeMemoryRangeAttributes (
       // The MMIO range is visible but has not been added to the memory space treat the region as not found.
       Status = EFI_NOT_FOUND;
     } else if (!EFI_ERROR (Status) &&
-        (
-         ((Descriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo) && (Descriptor.GcdMemoryType != EfiGcdMemoryTypeReserved)) ||
-         ((Descriptor.Length & EFI_PAGE_MASK) != 0)
-        )
-      )
+    (
+      ((Descriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo) && (Descriptor.GcdMemoryType != EfiGcdMemoryTypeReserved)) ||
+      ((Descriptor.Length & EFI_PAGE_MASK) != 0)
+     )
+     )
     {
       Status2 =  gDS->RemoveMemorySpace (
                         RuntimeMmioRanges->Range[Index].PhysicalBaseAddress,
                         Descriptor.Length
                         );
-    } 
+    }
 
     if ((Status == EFI_NOT_FOUND) || !EFI_ERROR (Status2)) {
       Status = gDS->AddMemorySpace (


### PR DESCRIPTION
## Description

This is regarding PRM modules that are describing MMIO ranges.

When `PrmConfigDxe` is calling `GetMemorySpaceDescriptor()` with a memory range that is visible to the boot processor but has not been added to the memory map `GetMemorySpaceDescriptor()` will return `EFI_SUCCESS` and then return a memory descriptor indicating that the region is non-existent. This causes `SetRuntimeMemoryRangeAttributes()` to believe that the region has already been added to the memory map and will eventually cause an `ASSERT`.

This PR allows for `SetRuntimeMemoryRangeAttributes()` to treat a non-existent MMIO range the same as a range that triggered a `EFI_NOT_FOUND` error response from `GetMemorySpaceDescriptor()`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Manual testing with non-existent MMIO range.

## Integration Instructions

N/A