### PR TITLE
[CHERRY-PICK][2405] Recent PrmPkg Changes [REBASE & FF]

### DIFF
--- a/PrmPkg/Include/PrmDataBuffer.h
+++ b/PrmPkg/Include/PrmDataBuffer.h
@@ -12,7 +12,7 @@
 
 #include <Uefi.h>
 
-#define PRM_DATA_BUFFER_HEADER_SIGNATURE  SIGNATURE_32('P','R','M','D')
+#define PRM_DATA_BUFFER_HEADER_SIGNATURE  SIGNATURE_32('P','R','M','S')
 
 #pragma pack(push, 1)
 

--- a/PrmPkg/PrmPkg.dsc
+++ b/PrmPkg/PrmPkg.dsc
@@ -12,7 +12,7 @@
   PLATFORM_VERSION               = 0.1
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
-  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64
+  SUPPORTED_ARCHITECTURES        = X64|AARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -40,7 +40,7 @@
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf # MU_CHANGE - CodeQL change
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
-[LibraryClasses.IA32, LibraryClasses.X64]
+[LibraryClasses.X64]
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
 
 [LibraryClasses.AARCH64]
@@ -145,9 +145,9 @@
   #
   $(PLATFORM_PACKAGE)/Application/PrmInfo/PrmInfo.inf
 
-[Components.IA32, Components.X64]
+[Components.X64]
   #
-  # PRM Sample Modules for IA32 and X64
+  # PRM Sample Modules for X64
   #
   $(PLATFORM_PACKAGE)/Samples/PrmSampleHardwareAccessModule/PrmSampleHardwareAccessModule.inf
 

--- a/PrmPkg/Readme.md
+++ b/PrmPkg/Readme.md
@@ -14,9 +14,9 @@ to be leveraged by platform firmware with minimal overhead to integrate PRM func
 `PlatformRtMechanism`. Support for this OperationRegion is planned for the next release of the ACPI specification.
 However, support for `PlatformRtMechanism` is already included in the iASL Compiler/Disassembler for early prototyping
 (i.e. this package). If you would like the default build to work and/or to use PRM handlers that are invoked
-through ACPI, iASL compiler [20200528](https://acpica.org/node/181) or greater must be used. If you are only
-interested in compiling the code and/or using direct call style PRM handlers, you can simply remove
-`PrmSsdtInstallDxe` from `PrmPkg.dsc`.
+through ACPI, iASL compiler [20200528](https://www.intel.com/content/www/us/en/download/774849/774861/acpi-component-architecture-downloads-previous-releases-2020.html)
+or greater must be used. If you are only interested in compiling the code and/or using direct call style PRM
+handlers, you can simply remove `PrmSsdtInstallDxe` from `PrmPkg.dsc`.
 
 The changes in the ACPI Specification include two elements:
 

--- a/PrmPkg/Readme.md
+++ b/PrmPkg/Readme.md
@@ -53,11 +53,13 @@ To build `PrmPkg` as a standalone package:
 
 5. Build PrmPkg \
 
-The PrmPkg can be built targetting the IA32/X64 and AArch64 architectures.
+The PrmPkg can be built targeting the X64 and AArch64 architectures. PRM is not supported on IA32 and ARM primarily
+because the OS support for PRM is only in 64 bit OSes. In addition, the MSVC toolchain does not support export tables
+on IA32 with the unique UEFI configuration required.
 
-* IA32/X64
+* X64
 
-   ``build -p PrmPkg/PrmPkg.dsc -a IA32 -a X64``
+   ``build -p PrmPkg/PrmPkg.dsc -a X64``
    > ***Note***: Due to the way PRM modules are compiled with exports, **only building on Visual Studio compiler tool
    chains has been tested**.
 

--- a/PrmPkg/Samples/PrmSampleAcpiParameterBufferModule/PrmSampleAcpiParameterBufferModule.inf
+++ b/PrmPkg/Samples/PrmSampleAcpiParameterBufferModule/PrmSampleAcpiParameterBufferModule.inf
@@ -8,6 +8,7 @@
 #
 #  Copyright (c) Microsoft Corporation
 #  Copyright (c) 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -41,5 +42,6 @@
   MSFT:*_*_*_DLINK_FLAGS  = /DLL /SUBSYSTEM:CONSOLE /VERSION:1.0
   MSFT:*_*_*_GENFW_FLAGS = --keepoptionalheader
 
-  GCC:*_*_AARCH64_GENFW_FLAGS = --prm
-  GCC:*_*_AARCH64_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckParamBufferPrmHandler
+  GCC:*_*_*_GENFW_FLAGS = --prm
+  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckParamBufferPrmHandler
+  GCC:*_*_X64_OBJCOPY_STRIPFLAG = --keep-symbol=PrmModuleExportDescriptor --keep-symbol=CheckParamBufferPrmHandler

--- a/PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
+++ b/PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
@@ -8,6 +8,7 @@
 #  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) Microsoft Corporation
 #  Copyright (c) 2022, Arm Limited. All rights reserved.<BR>
+#  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,5 +45,6 @@
   MSFT:*_*_*_DLINK_FLAGS  = /DLL /SUBSYSTEM:CONSOLE /VERSION:1.0
   MSFT:*_*_*_GENFW_FLAGS = --keepoptionalheader
 
-  GCC:*_*_AARCH64_GENFW_FLAGS = --keepoptionalheader --prm
-  GCC:*_*_AARCH64_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckStaticDataBufferPrmHandler
+  GCC:*_*_*_GENFW_FLAGS = --keepoptionalheader --prm
+  GCC:*_*_*_DLINK_FLAGS = -Wl,--no-gc-sections -Wl,--require-defined=PrmModuleExportDescriptor -Wl,--require-defined=CheckStaticDataBufferPrmHandler
+  GCC:*_*_X64_OBJCOPY_STRIPFLAG = --keep-symbol=PrmModuleExportDescriptor --keep-symbol=CheckStaticDataBufferPrmHandler

--- a/PrmPkg/Samples/Readme.md
+++ b/PrmPkg/Samples/Readme.md
@@ -23,10 +23,10 @@ location: \
 Note that the build command does provide the option to build a specific module in a package which can result in
 faster build time. If you would like to just build a single PRM module that can be done by specifying the path to
 the module INF file with the "-m" argument to `build`. For example, this command builds 32-bit and 64-bit binaries
-with Visual Studio 2019: \
+with Visual Studio 2022: \
 
 ```shell
-build -p PrmPkg/PrmPkg.dsc -m PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf -a IA32 -a X64 -t VS2019
+build -p PrmPkg/PrmPkg.dsc -m PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf -a X64 -t VS2022
 ```
 
 ## PRM Sample Module User's Guide


### PR DESCRIPTION
## Description

Cherry picks the improvements & fixes into 2405:

---

**[CHERRY-PICK] PrmPkg: Update link to ACPICA in Readme.md**

Links from acpica.org are now redirected to the ACPICA overview page
on intel.com. Update the link so it goes to the 20200517 download page.

Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
(cherry picked from commit 1e079360cd6f70ac26f0c808a35f14b3c4c56b85)

---

**[CHERRY-PICK] PrmPkg: Clarify Architecture Support**

Remove IA32 from supported architectures, as the MSVC build actually
fails due to the linker expecting a __stdcall calling convention.
IA32 PRMs are not supported anyway, only 64 bit OSes support PRM,
so simply drop the building of IA32 PrmPkg and clarify the README.
While there, clean up some markdown errors.

Signed-off-by: Oliver Smith-Denny <osde@microsoft.com>
(cherry picked from commit 81ba76f7df45b7bb18edae55375ea3b6abde4351)

---

**[CHERRY-PICK] PrmPkg: Align Data Buffer Signature to Spec**

edk2's PRM Data Buffer Signature is 'PRMD', however
PRM spec 1.0 section 4.2.1 Static Data Buffer indicates
that the signature should be 'PRMS'.

This commit aligns edk2's signature definition with the spec.

Signed-off-by: Oliver Smith-Denny <osde@microsoft.com>
(cherry picked from commit a093f6eccd8071ff32c60a6bfe54f97b9e07c6ef)

---

**[CHERRY-PICK] PrmPkg: Correct the flags for X64 GCC compiler**

Correct the GCC GenFw and ld flag to build PRM run time modules.
These changes are made for X64 GCC compiler, current present for AARCH64 only.
Adds addition _X64_OBJCOPY_STRIPFLAG for X64 to retain required symbol
during objcopy.

Signed-off-by: Abdul Lateef Attar <AbdulLateef.Attar@amd.com>
(cherry picked from commit 9006a9b5e4671ffc3d29c035260b19a8075c3f64)

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Tested in edk2 upstream

## Integration Instructions

- Be aware of the PRM Data Buffer Signature change. Not considered breaking
  since it matches the specification value.