### PR TITLE
Tcg2Dxe Pre-Install Event Log Lib

### DIFF
--- a/SecurityPkg/Include/Library/Tcg2PreInstallEventLogLib.h
+++ b/SecurityPkg/Include/Library/Tcg2PreInstallEventLogLib.h
@@ -1,0 +1,22 @@
+/** @file -- Tcg2PreInstallEventLogLib.h
+  This describes the interface that should be published by instances of the
+  Tcg2PreInstallEventLogLib. This library can be used to publish TPM EventLog
+  entries for measurements before the TCG2 protocol is installed.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef TCG_2_PRE_INSTALL_EVENT_LOG_LIB_H_
+#define TCG_2_PRE_INSTALL_EVENT_LOG_LIB_H_
+
+/**
+  Create the EventLog entries.
+**/
+VOID
+EFIAPI
+CreateTcg2PreInstallEventLogEntries (
+  VOID
+  );
+
+#endif // TCG_2_DXE_EVENT_LOG_LIB_H_

--- a/SecurityPkg/Include/Library/Tcg2PreInstallEventLogLib.h
+++ b/SecurityPkg/Include/Library/Tcg2PreInstallEventLogLib.h
@@ -1,7 +1,8 @@
 /** @file -- Tcg2PreInstallEventLogLib.h
   This describes the interface that should be published by instances of the
   Tcg2PreInstallEventLogLib. This library can be used to publish TPM EventLog
-  entries for measurements before the TCG2 protocol is installed.
+  entries for measurements before the TCG2 protocol is installed and for
+  platforms that start at the DXE phase.
 
 Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/SecurityPkg/Library/Tcg2PreInstallEventLogLibNull/Tcg2PreInstallEventLogLibNull.c
+++ b/SecurityPkg/Library/Tcg2PreInstallEventLogLibNull/Tcg2PreInstallEventLogLibNull.c
@@ -1,0 +1,19 @@
+/** @file Tcg2PreInstallEventLogLibNull.c
+ NULL Tcg2PreInstallEventLogLibNull library instance
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/**
+  Create the EventLog entries.
+**/
+VOID
+EFIAPI
+CreateTcg2PreInstallEventLogEntries (
+  VOID
+  )
+{
+  return;
+}

--- a/SecurityPkg/Library/Tcg2PreInstallEventLogLibNull/Tcg2PreInstallEventLogLibNull.inf
+++ b/SecurityPkg/Library/Tcg2PreInstallEventLogLibNull/Tcg2PreInstallEventLogLibNull.inf
@@ -1,0 +1,27 @@
+## @file Tcg2PreInstallEventLogLibNull.inf
+# Tcg2PreInstallEventLogLib Null library instance
+#
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = Tcg2PreInstallEventLogLibNull
+  FILE_GUID           = 2733B321-4C34-4302-843E-A83EB948191C
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = BASE
+  LIBRARY_CLASS       = Tcg2PreInstallEventLogLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  Tcg2PreInstallEventLogLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -138,6 +138,12 @@
   Tcg2PhysicalPresencePromptLib|Include/Library/Tcg2PhysicalPresencePromptLib.h
   ## MU_CHANGE [END]
 
+  ## MU_CHANGE
+  ##  @libraryclass  This library can be used to publish TPM EventLog entries
+  ##  for measurements before the Tcg2Dxe protocol is installed
+  #
+  Tcg2PreInstallEventLogLib|Include/Library/Tcg2PreInstallEventLogLib.h
+
   ##  @libraryclass Perform SPDM (following SPDM spec) and measure data to TPM (following TCG PFP spec).
   ##
   SpdmSecurityLib|Include/Library/SpdmSecurityLib.h

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -95,13 +95,13 @@
   MemLibWrapper|SecurityPkg/DeviceSecurity/OsStub/MemLibWrapper/MemLibWrapper.inf
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
+  Tcg2PreInstallEventLogLib|SecurityPkg/Library/Tcg2PreInstallEventLogLibNull/Tcg2PreInstallEventLogLibNull.inf  ## MU_CHANGE
+  Tcg2PreUefiEventLogLib|SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf  ## MU_CHANGE
+
   ## MU_CHANGE [BEGIN] - Measure Firmware Debugger Enabled
   DeviceStateLib|MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf 
   PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf 
   # MU_CHANGE [END]
-
-[LibraryClasses.X64, LibraryClasses.IA32]
-  Tcg2PreUefiEventLogLib|SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf  ## MU_CHANGE
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   #
@@ -286,6 +286,7 @@
   SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
   SecurityPkg/Library/Tcg2PhysicalPresencePromptLib/Tcg2PhysicalPresencePromptLibConsole.inf
   SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
+  SecurityPkg/Library/Tcg2PreInstallEventLogLibNull/Tcg2PreInstallEventLogLibNull.inf
 # MU_CHANGE [END]
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -54,6 +54,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DeviceStateLib.h>
 #include <Library/PanicLib.h>
 // MU_CHANGE [END]
+#include <Library/Tcg2PreInstallEventLogLib.h> // MU_CHANGE
 
 // #define PERF_ID_TCG2_DXE  0x3120 // MU_CHANGE
 
@@ -3035,6 +3036,9 @@ DriverEntry (
     //
     EfiCreateProtocolNotifyEvent (&gEfiResetNotificationProtocolGuid, TPL_CALLBACK, OnResetNotificationInstall, NULL, &Registration);
   }
+
+  // MU_CHANGE - Add support for measurements before the Tcg2 protocol is installed
+  CreateTcg2PreInstallEventLogEntries();
 
   //
   // Install Tcg2Protocol

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -3038,7 +3038,7 @@ DriverEntry (
   }
 
   // MU_CHANGE - Add support for measurements before the Tcg2 protocol is installed
-  CreateTcg2PreInstallEventLogEntries();
+  CreateTcg2PreInstallEventLogEntries ();
 
   //
   // Install Tcg2Protocol

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -75,6 +75,7 @@
   DeviceStateLib
   PanicLib
   ## MU_CHANGE [END]
+  Tcg2PreInstallEventLogLib  # MU_CHANGE
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"


### PR DESCRIPTION
## Description

Added new event log library for logging measurements before Tcg2Dxe has run and the protocol has been installed. This is there for platforms that need to log events that don't have a PEI phase for Tcg2PreUefiEventLogLib and to avoid reuse with this library which could break existing platforms. Library is a NULL instance and should do nothing unless overridden at the Platform level.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Verified by building SBSA and Q35 at the with updates to the .dsc to include the libraries. Note that SBSA does not support TPM and as such, did not include the Tcg2PreInstallEventLogLib. 

## Integration Instructions

Update the .dsc to include this new library
