### PR TITLE
[CHERRY PICK] Prevent Invalid DBX from being set and allow Empty DBX

### DIFF
--- a/SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.c
@@ -23,6 +23,21 @@
 #include <Library/SecureBootVariableLib.h>
 #include <Library/PlatformPKProtectionLib.h>
 
+//
+// This is the minimum size of a EFI_SIGNATURE_LIST and data and still be valid.
+//
+// The UEFI specification defines this as:
+//  Each signature list is a list of signatures of one type, identified by SignatureType.
+//  The signature list contains a header and then an array of zero or more signatures in
+//  the format specified by the header. The size of each signature in the signature list
+//  is specified by SignatureSize.
+//
+// This is the size of a signature list with some data in it. Effectively 44 bytes are
+// required to set the DBX. However in reality, the size of a real payload will be larger
+// since this miniumum size does not consider the SIGNATURE_LIST
+//
+#define MINIMUM_VALID_SIGNATURE_LIST  (sizeof(EFI_SIGNATURE_LIST) + sizeof(EFI_SIGNATURE_DATA) - 1)
+
 // This time can be used when deleting variables, as it should be greater than any variable time.
 EFI_TIME  mMaxTimestamp = {
   0xFFFF,     // Year
@@ -818,12 +833,27 @@ SetSecureBootVariablesToDefault (
   // dbx is a good place to start.
   Data     = (UINT8 *)SecureBootPayload->DbxPtr;
   DataSize = SecureBootPayload->DbxSize;
-  Status   = EnrollFromInput (
+  if (DataSize > MINIMUM_VALID_SIGNATURE_LIST) {
+    //
+    // Ensure that that the DataSize meets a minimum allowed size before being set.
+    //
+    DEBUG ((DEBUG_INFO, "%a - Setting Dbx\n", __func__));
+    Status = EnrollFromInput (
                EFI_IMAGE_SECURITY_DATABASE1,
                &gEfiImageSecurityDatabaseGuid,
                DataSize,
                Data
                );
+  } else if ((DataSize == 0) || (DataSize == sizeof (EFI_SIGNATURE_LIST))) {
+    //
+    // The DBX is allowed to be empty by default
+    //
+    DEBUG ((DEBUG_INFO, "%a - Skipping Dbx - DataSize(%u)\n", __func__, DataSize));
+    Status = EFI_SUCCESS;
+  } else {
+    DEBUG ((DEBUG_ERROR, "%a - Invalid Dbx size %u\n", __func__, DataSize));
+    Status = EFI_INVALID_PARAMETER;
+  }
 
   // If that went well, try the db (make sure to pick the right one!).
   if (!EFI_ERROR (Status)) {

--- a/SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.c
+++ b/SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.c
@@ -1217,13 +1217,20 @@ SetSecureBootVariablesShouldComplete (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbDummy     = 0xDE;
-  UINT8                     DbtDummy    = 0xAD;
-  UINT8                     DbxDummy    = 0xBE;
-  UINT8                     KekDummy    = 0xEF;
-  UINT8                     PkDummy     = 0xFE;
-  UINT8                     *Payload    = NULL;
-  UINTN                     PayloadSize = sizeof (DbDummy);
+  UINT8                     DbDummy    = 0xDE;
+  UINT8                     DbtDummy   = 0xAD;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  UINT8                     KekDummy = 0xEF;
+  UINT8                     PkDummy  = 0xFE;
+  UINT8                     *Payload = NULL;
+  UINTN                     PayloadSize;
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
 
   PayloadInfo.DbPtr             = &DbDummy;
@@ -1243,9 +1250,9 @@ SetSecureBootVariablesShouldComplete (
   expect_value (MockGetVariable, *DataSize, 0);
 
   will_return (MockGetVariable, FALSE);
-
-  Payload = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
-  Status  = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
+  Payload     = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
+  PayloadSize = sizeof (DbxDummy);
+  Status      = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
   UT_ASSERT_EQUAL (PayloadSize, VAR_AUTH_DESC_SIZE + sizeof (DbxDummy));
 
@@ -1387,7 +1394,14 @@ SetSecureBootVariablesShouldStopFailDBX (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbxDummy    = 0xBE;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
   UINT8                     *Payload    = NULL;
   UINTN                     PayloadSize = sizeof (DbxDummy);
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
@@ -1443,10 +1457,17 @@ SetSecureBootVariablesShouldStopFailDB (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbDummy     = 0xDE;
-  UINT8                     DbxDummy    = 0xBE;
-  UINT8                     *Payload    = NULL;
-  UINTN                     PayloadSize = sizeof (DbDummy);
+  UINT8                     DbDummy    = 0xDE;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  UINT8                     *Payload = NULL;
+  UINTN                     PayloadSize;
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
 
   PayloadInfo.DbPtr             = &DbDummy;
@@ -1461,8 +1482,9 @@ SetSecureBootVariablesShouldStopFailDB (
 
   will_return (MockGetVariable, FALSE);
 
-  Payload = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
-  Status  = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
+  Payload     = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
+  PayloadSize = sizeof (DbxDummy);
+  Status      = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
   UT_ASSERT_EQUAL (PayloadSize, VAR_AUTH_DESC_SIZE + sizeof (DbxDummy));
 
@@ -1516,11 +1538,18 @@ SetSecureBootVariablesShouldStopFailDBT (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbDummy     = 0xDE;
-  UINT8                     DbtDummy    = 0xAD;
-  UINT8                     DbxDummy    = 0xBE;
-  UINT8                     *Payload    = NULL;
-  UINTN                     PayloadSize = sizeof (DbDummy);
+  UINT8                     DbDummy    = 0xDE;
+  UINT8                     DbtDummy   = 0xAD;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  UINT8                     *Payload = NULL;
+  UINTN                     PayloadSize;
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
 
   PayloadInfo.DbPtr             = &DbDummy;
@@ -1537,8 +1566,9 @@ SetSecureBootVariablesShouldStopFailDBT (
 
   will_return (MockGetVariable, FALSE);
 
-  Payload = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
-  Status  = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
+  Payload     = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
+  PayloadSize = sizeof (DbxDummy);
+  Status      = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
   UT_ASSERT_EQUAL (PayloadSize, VAR_AUTH_DESC_SIZE + sizeof (DbxDummy));
 
@@ -1606,13 +1636,20 @@ SetSecureBootVariablesShouldStopFailKEK (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbDummy     = 0xDE;
-  UINT8                     DbtDummy    = 0xAD;
-  UINT8                     DbxDummy    = 0xBE;
-  UINT8                     KekDummy    = 0xEF;
-  UINT8                     PkDummy     = 0xFE;
-  UINT8                     *Payload    = NULL;
-  UINTN                     PayloadSize = sizeof (DbDummy);
+  UINT8                     DbDummy    = 0xDE;
+  UINT8                     DbtDummy   = 0xAD;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  UINT8                     KekDummy = 0xEF;
+  UINT8                     PkDummy  = 0xFE;
+  UINT8                     *Payload = NULL;
+  UINTN                     PayloadSize;
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
 
   PayloadInfo.DbPtr             = &DbDummy;
@@ -1633,8 +1670,9 @@ SetSecureBootVariablesShouldStopFailKEK (
 
   will_return (MockGetVariable, FALSE);
 
-  Payload = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
-  Status  = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
+  Payload     = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
+  PayloadSize = sizeof (DbxDummy);
+  Status      = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
   UT_ASSERT_EQUAL (PayloadSize, VAR_AUTH_DESC_SIZE + sizeof (DbxDummy));
 
@@ -1716,13 +1754,20 @@ SetSecureBootVariablesShouldStopFailPK (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbDummy     = 0xDE;
-  UINT8                     DbtDummy    = 0xAD;
-  UINT8                     DbxDummy    = 0xBE;
-  UINT8                     KekDummy    = 0xEF;
-  UINT8                     PkDummy     = 0xFE;
-  UINT8                     *Payload    = NULL;
-  UINTN                     PayloadSize = sizeof (DbDummy);
+  UINT8                     DbDummy    = 0xDE;
+  UINT8                     DbtDummy   = 0xAD;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  UINT8                     KekDummy = 0xEF;
+  UINT8                     PkDummy  = 0xFE;
+  UINT8                     *Payload = NULL;
+  UINTN                     PayloadSize;
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
 
   PayloadInfo.DbPtr             = &DbDummy;
@@ -1743,8 +1788,9 @@ SetSecureBootVariablesShouldStopFailPK (
 
   will_return (MockGetVariable, FALSE);
 
-  Payload = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
-  Status  = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
+  Payload     = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
+  PayloadSize = sizeof (DbxDummy);
+  Status      = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
   UT_ASSERT_EQUAL (PayloadSize, VAR_AUTH_DESC_SIZE + sizeof (DbxDummy));
 
@@ -1840,12 +1886,19 @@ SetSecureBootVariablesDBTOptional (
   )
 {
   EFI_STATUS                Status;
-  UINT8                     DbDummy     = 0xDE;
-  UINT8                     DbxDummy    = 0xBE;
-  UINT8                     KekDummy    = 0xEF;
-  UINT8                     PkDummy     = 0xFE;
-  UINT8                     *Payload    = NULL;
-  UINTN                     PayloadSize = sizeof (DbDummy);
+  UINT8                     DbDummy    = 0xDE;
+  UINT8                     DbxDummy[] = {
+    // Valid Dbx value (SHA256 hash of all 0x00)
+    0x26, 0x16, 0xC4, 0xC1, 0x4C, 0x50, 0x92, 0x40, 0xAC, 0xA9, 0x41, 0xF9, 0x36, 0x93, 0x43, 0x28,
+    0x4C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0xBD, 0x9A, 0xFA, 0x77,
+    0x59, 0x03, 0x32, 0x4D, 0xBD, 0x60, 0x28, 0xF4, 0xE7, 0x8F, 0x78, 0x4B, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+  UINT8                     KekDummy = 0xEF;
+  UINT8                     PkDummy  = 0xFE;
+  UINT8                     *Payload = NULL;
+  UINTN                     PayloadSize;
   SECURE_BOOT_PAYLOAD_INFO  PayloadInfo;
 
   PayloadInfo.DbPtr             = &DbDummy;
@@ -1866,8 +1919,9 @@ SetSecureBootVariablesDBTOptional (
 
   will_return (MockGetVariable, FALSE);
 
-  Payload = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
-  Status  = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
+  Payload     = AllocateCopyPool (sizeof (DbxDummy), &DbxDummy);
+  PayloadSize = sizeof (DbxDummy);
+  Status      = CreateTimeBasedPayload (&PayloadSize, &Payload, &mDefaultPayloadTimestamp);
   UT_ASSERT_NOT_EFI_ERROR (Status);
   UT_ASSERT_EQUAL (PayloadSize, VAR_AUTH_DESC_SIZE + sizeof (DbxDummy));
 


### PR DESCRIPTION
## Description

This PR adds the ability to skip the setting the Dbx variable if
the Default being provided is less than the size of the
EFI_SIGNATURE_LIST structure. This is to prevent the
setting of an invalid DBX which would cause the system to fail to boot.

Breakdown of the math is as follows:

1. **`sizeof(EFI_SIGNATURE_LIST)`**:
   - This is the size of the `EFI_SIGNATURE_LIST` structure itself,
   which includes:
     - `EFI_GUID SignatureType` (16 bytes)
     - `UINT32 SignatureListSize` (4 bytes)
     - `UINT32 SignatureHeaderSize` (4 bytes)
     - `UINT32 SignatureSize` (4 bytes)
   - Total: `16 + 4 + 4 + 4 = 28 bytes`

2. **`SignatureHeaderSize`**:
   - This is the size of the optional signature header. If no header is
   provided, this value is `0`.

3. **`SignatureSize`**:
   - This is the size of each `EFI_SIGNATURE_DATA` entry. For an empty
   list, this value is `0`.

The total size of an empty `EFI_SIGNATURE_LIST` is:
```c
sizeof(EFI_SIGNATURE_LIST) + SignatureHeaderSize
```

1. **No Signature Header**:
   - If `SignatureHeaderSize = 0`, the size is:
     ```c
     28 + 0 = 28 bytes
     ```

2. **With a Signature Header**:
   - If `SignatureHeaderSize = 16` (example size for a header), the
   size is:
     ```c
     28 + 16 = 44 bytes
     ```

- **Minimum Size**: `28 bytes` (if `SignatureHeaderSize = 0`).
- **Additional Size**: Add the value of `SignatureHeaderSize` if a
header is included.

If the DataSize = 0 (empty payload) or DataSize = 28 (valid empty efi signature list) the Dbx will be empty.

Original PR https://github.com/tianocore/edk2/pull/10937

- [ ] Impacts functionality?
- [X] Impacts security?
-  Allows for the DBX to be empty - that should be understood by platform integrators.
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Physical platform 

## Integration Instructions

N/A