### PR TITLE
Update MuTcg2Protocol

### DIFF
--- a/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
+++ b/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
@@ -40,8 +40,8 @@ EFI_STATUS
   );
 
 /**
-  The EFI_MU_TCG2_PROTOCOL MuEventInit function call provides callers with
-  an interface for initializing events before they are logged.
+  Initializes the provided TCG PCR Event2 Header structure based on its event type
+  so it is populated for further use such as logging.
 
   Supported Event Types:
   EV_NO_ACTION

--- a/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
+++ b/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
@@ -58,6 +58,7 @@ EFI_STATUS
 typedef
 EFI_STATUS
 (EFIAPI *MU_TCG2_INIT_EVENT)(
+  IN MU_TCG2_PROTOCOL        *This,
   IN OUT TCG_PCR_EVENT2_HDR  *Event,
   IN UINT32                  EventSize
   );

--- a/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
+++ b/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
@@ -12,7 +12,7 @@
 #include <IndustryStandard/Tpm20.h>
 #include <Protocol/Tcg2Protocol.h>
 
-#define MU_TCG2_PROTOCOL_VERSION  1
+#define MU_TCG2_PROTOCOL_VERSION  2
 
 typedef struct tdMU_TCG2_PROTOCOL MU_TCG2_PROTOCOL;
 
@@ -39,6 +39,22 @@ EFI_STATUS
   IN EFI_TCG2_EVENT       *Event
   );
 
+/**
+  The EFI_MU_TCG2_PROTOCOL MuEventInit function call provides callers with
+  an interface for initializing events before they are logged.
+
+  Supported Event Types:
+  EV_NO_ACTION
+  EV_EFI_HCRTM_EVENT
+
+  @param[in]      This             Indicates the calling context
+  @param[in/out]  Event            Pointer to the event to initialize
+  @param[in]      EventSize        Size of the event
+
+  @retval EFI_SUCCESS            Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER  One or more of the parameters are incorrect.
+  @retval EFI_UNSUPPORTED        The event provided is unsupported
+**/
 typedef
 EFI_STATUS
 (EFIAPI *MU_TCG2_INIT_EVENT)(

--- a/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
+++ b/SecurityPkg/Include/Protocol/MuTcg2Protocol.h
@@ -38,11 +38,19 @@ EFI_STATUS
   IN TPML_DIGEST_VALUES   *DigestList,
   IN EFI_TCG2_EVENT       *Event
   );
+
+typedef
+EFI_STATUS
+(EFIAPI *MU_TCG2_INIT_EVENT)(
+  IN OUT TCG_PCR_EVENT2_HDR  *Event,
+  IN UINT32                  EventSize
+  );
 // MU_CHANGE - END - Add a new protocol to support Log-only events.
 
 struct tdMU_TCG2_PROTOCOL {
-  UINT32               Version;
-  MU_TCG2_LOG_EVENT    Tcg2LogEvent;
+  UINT32                Version;
+  MU_TCG2_LOG_EVENT     Tcg2LogEvent;
+  MU_TCG2_INIT_EVENT    Tcg2InitEvent;
 };
 
 extern EFI_GUID  gMuTcg2ProtocolExGuid;

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -1447,8 +1447,8 @@ Tcg2LogEvent (
 }
 
 /**
-  The EFI_MU_TCG2_PROTOCOL MuEventInit function call provides callers with
-  an interface for initializing events before they are logged.
+  Initializes the provided TCG PCR Event2 Header structure based on its event type
+  so it is populated for further use such as logging.
 
   Supported Event Types:
   EV_NO_ACTION
@@ -1465,6 +1465,7 @@ Tcg2LogEvent (
 EFI_STATUS
 EFIAPI
 Tcg2InitEvent (
+  IN MU_TCG2_PROTOCOL        *This,
   IN OUT TCG_PCR_EVENT2_HDR  *Event,
   IN UINT32                  EventSize
   )
@@ -1474,7 +1475,7 @@ Tcg2InitEvent (
 
   DEBUG ((DEBUG_VERBOSE, "%a - Entry\n", __func__));
 
-  if (Event == NULL) {
+  if ((This == NULL) || (Event == NULL)) {
     Status = EFI_INVALID_PARAMETER;
     goto Exit;
   }

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -1418,7 +1418,7 @@ Tcg2LogEvent (
   EFI_STATUS         Status;
   TCG_PCR_EVENT_HDR  NewEventHdr;
 
-  DEBUG ((DEBUG_VERBOSE, "%a - Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a - Entry\n", __func__));
 
   if ((This == NULL) || (Event == NULL) || (DigestList == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -1442,10 +1442,26 @@ Tcg2LogEvent (
 
   Status = TcgDxeLogHashEvent (DigestList, &NewEventHdr, Event->Event);
 
-  DEBUG ((DEBUG_VERBOSE, "%a - Exit. Status = %r\n", __FUNCTION__, Status));
+  DEBUG ((DEBUG_VERBOSE, "%a - Exit. Status = %r\n", __func__, Status));
   return Status;
 }
 
+/**
+  The EFI_MU_TCG2_PROTOCOL MuEventInit function call provides callers with
+  an interface for initializing events before they are logged.
+
+  Supported Event Types:
+  EV_NO_ACTION
+  EV_EFI_HCRTM_EVENT
+
+  @param[in]      This             Indicates the calling context
+  @param[in/out]  Event            Pointer to the event to initialize
+  @param[in]      EventSize        Size of the event
+
+  @retval EFI_SUCCESS            Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER  One or more of the parameters are incorrect.
+  @retval EFI_UNSUPPORTED        The event provided is unsupported
+**/
 EFI_STATUS
 EFIAPI
 Tcg2InitEvent (
@@ -1456,7 +1472,7 @@ Tcg2InitEvent (
   EFI_STATUS     Status;
   TCG_EVENTTYPE  EventType;
 
-  DEBUG ((DEBUG_VERBOSE, "%a - Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a - Entry\n", __func__));
 
   if (Event == NULL) {
     Status = EFI_INVALID_PARAMETER;
@@ -1470,10 +1486,11 @@ Tcg2InitEvent (
     Event->EventType = EventType;
   } else {
     // TODO: Add init for other event types
+    Status = EFI_UNSUPPORTED;
   }
 
 Exit:
-  DEBUG ((DEBUG_VERBOSE, "%a - Exit. Status = %r\n", __FUNCTION__, Status));
+  DEBUG ((DEBUG_VERBOSE, "%a - Exit. Status = %r\n", __func__, Status));
   return Status;
 }
 

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -1446,6 +1446,37 @@ Tcg2LogEvent (
   return Status;
 }
 
+EFI_STATUS
+EFIAPI
+Tcg2InitEvent (
+  IN OUT TCG_PCR_EVENT2_HDR  *Event,
+  IN UINT32                  EventSize
+  )
+{
+  EFI_STATUS     Status;
+  TCG_EVENTTYPE  EventType;
+
+  DEBUG ((DEBUG_VERBOSE, "%a - Entry\n", __FUNCTION__));
+
+  if (Event == NULL) {
+    Status = EFI_INVALID_PARAMETER;
+    goto Exit;
+  }
+
+  Status = EFI_SUCCESS;
+  if ((Event->EventType == EV_NO_ACTION) || (Event->EventType == EV_EFI_HCRTM_EVENT)) {
+    EventType = Event->EventType;
+    InitNoActionEvent (Event, EventSize);
+    Event->EventType = EventType;
+  } else {
+    // TODO: Add init for other event types
+  }
+
+Exit:
+  DEBUG ((DEBUG_VERBOSE, "%a - Exit. Status = %r\n", __FUNCTION__, Status));
+  return Status;
+}
+
 // MU_CHANGE - END - Add a new protocol to support Log-only events.
 
 /**
@@ -1617,7 +1648,8 @@ Tcg2GetResultOfSetActivePcrBanks (
 // MU_CHANGE - START - Add a new protocol to support Log-only events.
 MU_TCG2_PROTOCOL  mMuTcg2Protocol = {
   MU_TCG2_PROTOCOL_VERSION,
-  Tcg2LogEvent
+  Tcg2LogEvent,
+  Tcg2InitEvent,
 };
 // MU_CHANGE - END - Add a new protocol to support Log-only events.
 


### PR DESCRIPTION
## Description

Updated the MuTcg2Protocol to include a function to initialize an event. This is used alongside Tcg2LogEvent to log and NOT extend events.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Built and tested using a driver to register for the protocol to be installed. Once installed, a callback is invoked which logs events. 

## Integration Instructions

N/A