### PR TITLE
[REBASE & FF] Clean Up Noisy TCG Prints

### DIFF
--- a/SecurityPkg/Include/Library/Tpm2DebugLib.h
+++ b/SecurityPkg/Include/Library/Tpm2DebugLib.h
@@ -10,6 +10,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef TPM_2_DEBUG_LIB_H_
 #define TPM_2_DEBUG_LIB_H_
 
+#include <Protocol/Tcg2Protocol.h>
+
 /**
   This function dumps as much information as possible about
   a command being sent to the TPM for maximum user-readability.
@@ -38,6 +40,39 @@ EFIAPI
 DumpTpmOutputBlock (
   IN UINT32       OutputBlockSize,
   IN CONST UINT8  *OutputBlock
+  );
+
+/**
+  This function dumps the provided event log.
+
+  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+                                 address of the start of the last entry in the event log in memory.
+  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+**/
+VOID
+EFIAPI
+DumpEventLog (
+  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+  );
+
+/**
+  This function dumps the provided PCR digest.
+
+  @param[in]  PcrIndex   The index of the PCR.
+  @param[in]  HashAlg    The hash algorithm used.
+  @param[in]  PcrValues  The digest to be dumped.
+**/
+VOID
+EFIAPI
+DumpPcrDigest (
+  IN UINT32         PcrIndex,
+  IN TPMI_ALG_HASH  HashAlg,
+  IN TPML_DIGEST    *PcrValues
   );
 
 #endif // TPM_2_DEBUG_LIB_H_

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -327,7 +327,7 @@ Tcg2MeasureGptTable (
       mTcg2MeasureGptCount++;
     }
 
-    DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Cc MeasureGptTable - %r\n", Status));
+    // DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Cc MeasureGptTable - %r\n", Status)); MU_CHANGE: Remove noisy print
   } else if (Tcg2Protocol != NULL) {
     //
     // If Tcg2Protocol is installed, then Measure GPT data with this protocol.
@@ -343,7 +343,7 @@ Tcg2MeasureGptTable (
       mTcg2MeasureGptCount++;
     }
 
-    DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Tcg2 MeasureGptTable - %r\n", Status));
+    // DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Tcg2 MeasureGptTable - %r\n", Status)); MU_CHANGE: Remove noisy print
   }
 
 Exit:
@@ -495,7 +495,7 @@ Tcg2MeasurePeImage (
                            ImageSize,
                            CcEvent
                            );
-    DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Cc MeasurePeImage - %r\n", Status));
+    // DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Cc MeasurePeImage - %r\n", Status)); MU_CHANGE: Remove noisy print
   } else if (Tcg2Protocol != NULL) {
     Status = Tcg2Protocol->HashLogExtendEvent (
                              Tcg2Protocol,
@@ -504,7 +504,7 @@ Tcg2MeasurePeImage (
                              ImageSize,
                              Tcg2Event
                              );
-    DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Tcg2 MeasurePeImage - %r\n", Status));
+    // DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - Tcg2 MeasurePeImage - %r\n", Status)); MU_CHANGE: Remove noisy print
   }
 
   if (Status == EFI_VOLUME_FULL) {
@@ -665,14 +665,14 @@ DxeTpm2MeasureBootHandler (
     return EFI_SUCCESS;
   }
 
-  DEBUG (
-    (
-     DEBUG_INFO,
-     "Tcg2Protocol = %p, CcMeasurementProtocol = %p\n",
-     MeasureBootProtocols.Tcg2Protocol,
-     MeasureBootProtocols.CcProtocol
-    )
-    );
+  // DEBUG (
+  //   (
+  //    DEBUG_INFO,
+  //    "Tcg2Protocol = %p, CcMeasurementProtocol = %p\n",
+  //    MeasureBootProtocols.Tcg2Protocol,
+  //    MeasureBootProtocols.CcProtocol
+  //   )
+  //   ); // MU_CHANGE: Remove noisy prints
 
   //
   // Copy File Device Path
@@ -886,7 +886,7 @@ DxeTpm2MeasureBootHandler (
                TRUE
                );
     if (ToText != NULL) {
-      DEBUG ((DEBUG_INFO, "The measured image path is %s.\n", ToText));
+      DEBUG ((DEBUG_VERBOSE, "The measured image path is %s.\n", ToText)); // MU_CHANGE: Downgrade noisy prints
       FreePool (ToText);
     }
 
@@ -913,7 +913,7 @@ Finish:
     FreePool (OrigDevicePathNode);
   }
 
-  DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - %r\n", Status));
+  // DEBUG ((DEBUG_INFO, "DxeTpm2MeasureBootHandler - %r\n", Status)); MU_CHANGE: Remove noisy print
 
   return Status;
 }

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Capability.c
@@ -538,7 +538,7 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
   // Get supported PCR
   //
   Status = Tpm2GetCapabilityPcrs (&Pcrs);
-  DEBUG ((DEBUG_INFO, "Supported PCRs - Count = %08x\n", Pcrs.count));
+  // DEBUG ((DEBUG_INFO, "Supported PCRs - Count = %08x\n", Pcrs.count)); MU_CHANGE: Remove noisy print
   ActivePcrBankCount = 0;
   //
   // If error, assume that we have at least SHA-1 (and return the error.)
@@ -616,7 +616,7 @@ Tpm2GetCapabilitySupportedAndActivePcrs (
     }
   }
 
-  DEBUG ((DEBUG_INFO, "GetSupportedAndActivePcrs - Count = %08x\n", ActivePcrBankCount));
+  DEBUG ((DEBUG_VERBOSE, "GetSupportedAndActivePcrs - Count = %08x\n", ActivePcrBankCount)); // MU_CHANGE: Downgrade print
   return Status;
 }
 

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
@@ -48,3 +48,4 @@
   BaseMemoryLib
   DebugLib
   Tpm2DeviceLib
+  Tpm2DebugLib # MU_CHANGE - Add Tpm2DebugLib

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2DebugLib.h> // MU_CHANGE: Move noisy prints to debug lib
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
@@ -757,7 +758,8 @@ Tpm2PcrReadForActiveBank (
   UINT32              ActivePcrBanks;
   UINT32              TcgRegistryHashAlg;
   UINTN               Index;
-  UINTN               Index2;
+
+  // UINTN               Index2; MU_CHANGE: Use debug lib
 
   PcrIndex = (UINT8)PcrHandle;
 
@@ -868,20 +870,27 @@ Tpm2PcrReadForActiveBank (
     return EFI_DEVICE_ERROR;
   }
 
-  for (Index = 0; Index < PcrValues.count; Index++) {
-    DEBUG ((
-      DEBUG_INFO,
-      "ReadPcr - HashAlg = 0x%04x, Pcr[%02d], digest = ",
-      PcrSelectionOut.pcrSelections[Index].hash,
-      PcrIndex
-      ));
+  // MU_CHANGE Start: Use debug lib
+  // for (Index = 0; Index < PcrValues.count; Index++) {
+  //   DEBUG ((
+  //     DEBUG_INFO,
+  //     "ReadPcr - HashAlg = 0x%04x, Pcr[%02d], digest = ",
+  //     PcrSelectionOut.pcrSelections[Index].hash,
+  //     PcrIndex
+  //     ));
 
-    for (Index2 = 0; Index2 < PcrValues.digests[Index].size; Index2++) {
-      DEBUG ((DEBUG_INFO, "%02x ", PcrValues.digests[Index].buffer[Index2]));
-    }
+  //   for (Index2 = 0; Index2 < PcrValues.digests[Index].size; Index2++) {
+  //     DEBUG ((DEBUG_INFO, "%02x ", PcrValues.digests[Index].buffer[Index2]));
+  //   }
 
-    DEBUG ((DEBUG_INFO, "\n"));
-  }
+  //   DEBUG ((DEBUG_INFO, "\n"));
+  // }
+  DumpPcrDigest (
+    PcrIndex,
+    PcrSelectionOut.pcrSelections[Index].hash,
+    &PcrValues
+    );
+  // MU_CHANGE END: Use debug lib
 
   if (HashList != NULL) {
     CopyMem (

--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2Integrity.c
@@ -773,7 +773,7 @@ Tpm2PcrReadForActiveBank (
   ZeroMem (&PcrValues, sizeof (PcrValues));
   ZeroMem (&Pcrs, sizeof (TPML_PCR_SELECTION));
 
-  DEBUG ((DEBUG_INFO, "ReadPcr - %02d\n", PcrIndex));
+  // DEBUG ((DEBUG_INFO, "ReadPcr - %02d\n", PcrIndex)); MU_CHANGE: Remove noisy print
 
   //
   // Read TPM capabilities

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.c
@@ -6,6 +6,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#include <Uefi.h>
+#include <Library/Tpm2DebugLib.h>
+
 /**
   This function dumps as much information as possible about
   a command being sent to the TPM for maximum user-readability.

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.c
@@ -46,7 +46,7 @@ DumpTpmOutputBlock (
 } // DumpTpmOutputBlock()
 
 /**
-  This function dump event log.
+  This function dumps the provided event log.
 
   @param[in]  EventLogFormat     The type of the event log for which the information is requested.
   @param[in]  EventLogLocation   A pointer to the memory address of the event log.

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.c
@@ -44,3 +44,42 @@ DumpTpmOutputBlock (
 {
   return;
 } // DumpTpmOutputBlock()
+
+/**
+  This function dump event log.
+
+  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+                                 address of the start of the last entry in the event log in memory.
+  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+**/
+VOID
+EFIAPI
+DumpEventLog (
+  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+  )
+{
+  return;
+}
+
+/**
+  This function dumps the provided PCR digest.
+
+  @param[in]  PcrIndex   The index of the PCR.
+  @param[in]  HashAlg    The hash algorithm used.
+  @param[in]  PcrValues  The digest to be dumped.
+**/
+VOID
+EFIAPI
+DumpPcrDigest (
+  IN UINT32         PcrIndex,
+  IN TPMI_ALG_HASH  HashAlg,
+  IN TPML_DIGEST    *PcrValues
+  )
+{
+  return;
+}

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
@@ -19,17 +19,12 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = ALL
 #
-
 
 [Sources]
   Tpm2DebugLibNull.c
 
-
 [Packages]
   MdePkg/MdePkg.dec
-
-
-[LibraryClasses]
-  DebugLib
+  SecurityPkg/SecurityPkg.dec

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.c
@@ -80,3 +80,49 @@ DumpTpmOutputBlock (
 
   return;
 } // DumpTpmOutputBlock()
+
+/**
+  This function dump event log.
+
+  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+                                 address of the start of the last entry in the event log in memory.
+  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+**/
+VOID
+EFIAPI
+DumpEventLog (
+  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+  )
+{
+  // Dumping the entire event log is left for the verbose version of this library, because it can be thousands of
+  // lines long.
+  DEBUG ((DEBUG_INFO, "EventLogFormat - 0x%llx\n", EventLogFormat));
+  DEBUG ((DEBUG_INFO, "EventLogLocation - 0x%llx\n", EventLogLocation));
+  DEBUG ((DEBUG_INFO, "EventLogLastEntry - 0x%llx\n", EventLogLastEntry));
+  DEBUG ((DEBUG_INFO, "FinalEventsTable - 0x%llx\n", FinalEventsTable));
+}
+
+/**
+  This function dumps the provided PCR digest.
+
+  @param[in]  PcrIndex   The index of the PCR.
+  @param[in]  HashAlg    The hash algorithm used.
+  @param[in]  PcrValues  The digest to be dumped.
+**/
+VOID
+EFIAPI
+DumpPcrDigest (
+  IN UINT32         PcrIndex,
+  IN TPMI_ALG_HASH  HashAlg,
+  IN TPML_DIGEST    *PcrValues
+  )
+{
+  // This function simply marks we have read these PCRs, the verbose version of this function will dump the contents.
+  DEBUG ((DEBUG_INFO, "PcrIndex - %d\n", PcrIndex));
+  DEBUG ((DEBUG_INFO, "HashAlg - 0x%04x\n", HashAlg));
+}

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.c
@@ -82,7 +82,7 @@ DumpTpmOutputBlock (
 } // DumpTpmOutputBlock()
 
 /**
-  This function dump event log.
+  This function dumps the provided event log.
 
   @param[in]  EventLogFormat     The type of the event log for which the information is requested.
   @param[in]  EventLogLocation   A pointer to the memory address of the event log.

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.c
@@ -7,7 +7,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#include <Uefi.h>
 #include <Library/DebugLib.h>
+#include <Library/Tpm2DebugLib.h>
 
 /**
   This function dumps as much information as possible about

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.inf
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.inf
@@ -20,17 +20,16 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = ALL
 #
 
 
 [Sources]
   Tpm2DebugLibSimple.c
 
-
 [Packages]
   MdePkg/MdePkg.dec
-
+  SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
   DebugLib

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.c
@@ -12,9 +12,11 @@ MU_CHANGE
 #include <Uefi.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/Tpm2DebugLib.h>
 
 #include <IndustryStandard/Tpm20.h>
+#include <IndustryStandard/UefiTcgPlatform.h>
 
 #define MAX_TPM_BUFFER_DUMP  240          // If printing an entire buffer, only print up to MAX bytes.
 
@@ -738,3 +740,417 @@ DumpTpmOutputBlock (
 
   return;
 } // DumpTpmOutputBlock()
+
+/**
+
+  This function dump raw data.
+
+  @param  Data  raw data
+  @param  Size  raw data size
+
+**/
+STATIC
+VOID
+InternalDumpData (
+  IN UINT8  *Data,
+  IN UINTN  Size
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < Size; Index++) {
+    DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
+  }
+}
+
+/**
+
+  This function dump raw data with colume format.
+
+  @param  Data  raw data
+  @param  Size  raw data size
+
+**/
+STATIC
+VOID
+InternalDumpHex (
+  IN UINT8  *Data,
+  IN UINTN  Size
+  )
+{
+  UINTN  Index;
+  UINTN  Count;
+  UINTN  Left;
+
+  #define COLUME_SIZE  (16 * 2)
+
+  Count = Size / COLUME_SIZE;
+  Left  = Size % COLUME_SIZE;
+  for (Index = 0; Index < Count; Index++) {
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+    InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
+    DEBUG ((DEBUG_INFO, "\n"));
+  }
+
+  if (Left != 0) {
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+    InternalDumpData (Data + Index * COLUME_SIZE, Left);
+    DEBUG ((DEBUG_INFO, "\n"));
+  }
+}
+
+/**
+  This function dump PCR event.
+
+  @param[in]  EventHdr     TCG PCR event structure.
+**/
+STATIC
+VOID
+DumpEvent (
+  IN TCG_PCR_EVENT_HDR  *EventHdr
+  )
+{
+  UINTN  Index;
+
+  DEBUG ((DEBUG_INFO, "  Event:\n"));
+  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
+  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
+  DEBUG ((DEBUG_INFO, "    Digest    - "));
+  for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
+    DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
+  InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
+}
+
+/**
+  This function dump PCR event 2.
+
+  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+**/
+STATIC
+VOID
+DumpEvent2 (
+  IN TCG_PCR_EVENT2  *TcgPcrEvent2
+  )
+{
+  UINTN          Index;
+  UINT32         DigestIndex;
+  UINT32         DigestCount;
+  TPMI_ALG_HASH  HashAlgo;
+  UINT32         DigestSize;
+  UINT8          *DigestBuffer;
+  UINT32         EventSize;
+  UINT8          *EventBuffer;
+
+  DEBUG ((DEBUG_INFO, "  Event:\n"));
+  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
+  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
+
+  DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
+
+  DigestCount  = TcgPcrEvent2->Digest.count;
+  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+    DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
+    DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
+    switch (HashAlgo) {
+      case TPM_ALG_SHA1:
+        DigestSize = SHA1_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA256:
+        DigestSize = SHA256_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA384:
+        DigestSize = SHA384_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA512:
+        DigestSize = SHA512_DIGEST_SIZE;
+        break;
+      default:
+        DEBUG ((DEBUG_ERROR, "Unknown Hash Algorithm\n"));
+        continue;
+    }
+
+    for (Index = 0; Index < DigestSize; Index++) {
+      DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
+    }
+
+    DEBUG ((DEBUG_INFO, "\n"));
+    //
+    // Prepare next
+    //
+    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+
+  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
+  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+  InternalDumpHex (EventBuffer, EventSize);
+}
+
+/**
+  This function dump TCG_EfiSpecIDEventStruct.
+
+  @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+**/
+STATIC
+VOID
+DumpTcgEfiSpecIdEventStruct (
+  IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
+  )
+{
+  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+  UINTN                            Index;
+  UINT8                            *VendorInfoSize;
+  UINT8                            *VendorInfo;
+  UINT32                           NumberOfAlgorithms;
+
+  DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
+  DEBUG ((DEBUG_INFO, "    signature          - '"));
+  for (Index = 0; Index < sizeof (TcgEfiSpecIdEventStruct->signature); Index++) {
+    DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "'\n"));
+  DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
+  DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
+  DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
+
+  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+  DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
+
+  DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+  for (Index = 0; Index < NumberOfAlgorithms; Index++) {
+    DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
+    DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
+    DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
+  }
+
+  VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
+  DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
+  VendorInfo = VendorInfoSize + 1;
+  DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
+  for (Index = 0; Index < *VendorInfoSize; Index++) {
+    DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+}
+
+/**
+  This function gets the size of TCG_EfiSpecIDEventStruct. It is copied here as it is a simple calculation and to
+  avoid library dependencies within TCG2 code.
+
+  @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+**/
+STATIC
+UINTN
+Tpm2DebugLibGetTcgEfiSpecIdEventStructSize (
+  IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
+  )
+{
+  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+  UINT8                            *VendorInfoSize;
+  UINT32                           NumberOfAlgorithms;
+
+  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+
+  DigestSize     = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+  VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
+  return sizeof (TCG_EfiSpecIDEventStruct) + sizeof (UINT32) + (NumberOfAlgorithms * sizeof (TCG_EfiSpecIdEventAlgorithmSize)) + sizeof (UINT8) + (*VendorInfoSize);
+}
+
+/**
+  This function returns size of TCG PCR event 2.
+
+  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+
+  @return size of TCG PCR event 2.
+**/
+STATIC
+UINTN
+GetPcrEvent2Size (
+  IN TCG_PCR_EVENT2  *TcgPcrEvent2
+  )
+{
+  UINT32         DigestIndex;
+  UINT32         DigestCount;
+  TPMI_ALG_HASH  HashAlgo;
+  UINT32         DigestSize;
+  UINT8          *DigestBuffer;
+  UINT32         EventSize;
+  UINT8          *EventBuffer;
+
+  DigestCount  = TcgPcrEvent2->Digest.count;
+  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+    switch (HashAlgo) {
+      case TPM_ALG_SHA1:
+        DigestSize = SHA1_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA256:
+        DigestSize = SHA256_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA384:
+        DigestSize = SHA384_DIGEST_SIZE;
+        break;
+      case TPM_ALG_SHA512:
+        DigestSize = SHA512_DIGEST_SIZE;
+        break;
+      default:
+        DEBUG ((DEBUG_ERROR, "Unknown Hash Algorithm\n"));
+        continue;
+    }
+
+    //
+    // Prepare next
+    //
+    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+  }
+
+  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+
+  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+
+  return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
+}
+
+/**
+  This function dump event log.
+
+  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+                                 address of the start of the last entry in the event log in memory.
+  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+**/
+VOID
+EFIAPI
+DumpEventLog (
+  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+  )
+{
+  TCG_PCR_EVENT_HDR         *EventHdr;
+  TCG_PCR_EVENT2            *TcgPcrEvent2;
+  TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
+  UINT64                    NumberOfEvents; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+
+  DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
+
+  switch (EventLogFormat) {
+    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
+      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
+        // MU_CHANGE - CodeQL Change
+        DumpEvent (EventHdr);
+        EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+      }
+
+      if (FinalEventsTable == NULL) {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+      } else {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+
+        EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
+        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+          DumpEvent (EventHdr);
+          EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+        }
+      }
+
+      break;
+    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
+      //
+      // Dump first event
+      //
+      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+      DumpEvent (EventHdr);
+
+      TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)(EventHdr + 1);
+      DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
+
+      TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + Tpm2DebugLibGetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
+      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+        // MU_CHANGE -  CodeQL
+        DumpEvent2 (TcgPcrEvent2);
+        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+      }
+
+      if (FinalEventsTable == NULL) {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+      } else {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+
+        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
+        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+          DumpEvent2 (TcgPcrEvent2);
+          TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+        }
+      }
+
+      break;
+  }
+
+  return;
+}
+
+/**
+  This function dumps the provided PCR digest.
+
+  @param[in]  PcrIndex   The index of the PCR.
+  @param[in]  HashAlg    The hash algorithm used.
+  @param[in]  PcrValues  The digest to be dumped.
+**/
+VOID
+EFIAPI
+DumpPcrDigest (
+  IN UINT32         PcrIndex,
+  IN TPMI_ALG_HASH  HashAlg,
+  IN TPML_DIGEST    *PcrValues
+  )
+{
+  UINTN  Index;
+  UINTN  Index2;
+
+  if (PcrValues == NULL) {
+    DEBUG ((DEBUG_INFO, "DumpPcrDigest - PcrValues is NULL\n"));
+    return;
+  }
+
+  for (Index = 0; Index < PcrValues->count; Index++) {
+    DEBUG ((
+      DEBUG_INFO,
+      "ReadPcr - HashAlg = 0x%04x, Pcr[%02d], digest = ",
+      HashAlg,
+      PcrIndex
+      ));
+
+    for (Index2 = 0; Index2 < PcrValues->digests[Index].size; Index2++) {
+      if ((PcrValues->digests == NULL) || (PcrValues->digests[Index].buffer == NULL)) {
+        DEBUG ((DEBUG_INFO, "NULL\n"));
+      } else {
+        DEBUG ((DEBUG_INFO, "%02x ", PcrValues->digests[Index].buffer[Index2]));
+      }
+    }
+
+    DEBUG ((DEBUG_INFO, "\n"));
+  }
+}

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.c
@@ -743,10 +743,10 @@ DumpTpmOutputBlock (
 
 /**
 
-  This function dump raw data.
+  This function dumps raw data.
 
-  @param  Data  raw data
-  @param  Size  raw data size
+  @param[in]  Data  raw data
+  @param[in]  Size  raw data size
 
 **/
 STATIC
@@ -765,10 +765,10 @@ InternalDumpData (
 
 /**
 
-  This function dump raw data with colume format.
+  This function dumps raw data formatted in columns.
 
-  @param  Data  raw data
-  @param  Size  raw data size
+  @param[in]  Data  raw data
+  @param[in]  Size  raw data size
 
 **/
 STATIC
@@ -782,25 +782,25 @@ InternalDumpHex (
   UINTN  Count;
   UINTN  Left;
 
-  #define COLUME_SIZE  (16 * 2)
+  #define COLUMN_SIZE  (16 * 2)
 
-  Count = Size / COLUME_SIZE;
-  Left  = Size % COLUME_SIZE;
+  Count = Size / COLUMN_SIZE;
+  Left  = Size % COLUMN_SIZE;
   for (Index = 0; Index < Count; Index++) {
-    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
-    InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUMN_SIZE));
+    InternalDumpData (Data + Index * COLUMN_SIZE, COLUMN_SIZE);
     DEBUG ((DEBUG_INFO, "\n"));
   }
 
   if (Left != 0) {
-    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
-    InternalDumpData (Data + Index * COLUME_SIZE, Left);
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUMN_SIZE));
+    InternalDumpData (Data + Index * COLUMN_SIZE, Left);
     DEBUG ((DEBUG_INFO, "\n"));
   }
 }
 
 /**
-  This function dump PCR event.
+  This function dumps PCR events.
 
   @param[in]  EventHdr     TCG PCR event structure.
 **/
@@ -816,7 +816,7 @@ DumpEvent (
   DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
   DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
   DEBUG ((DEBUG_INFO, "    Digest    - "));
-  for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
+  for (Index = 0; Index < sizeof (EventHdr->Digest); Index++) {
     DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
   }
 
@@ -826,7 +826,7 @@ DumpEvent (
 }
 
 /**
-  This function dump PCR event 2.
+  This function dumps TCG_PCR_EVENT2 type events.
 
   @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
 **/
@@ -890,14 +890,14 @@ DumpEvent2 (
   DEBUG ((DEBUG_INFO, "\n"));
   DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
 
-  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+  CopyMem (&EventSize, DigestBuffer, sizeof (EventSize));
   DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
   EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
   InternalDumpHex (EventBuffer, EventSize);
 }
 
 /**
-  This function dump TCG_EfiSpecIDEventStruct.
+  This function dumps a TCG_EfiSpecIDEventStruct structure.
 
   @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
 **/
@@ -950,6 +950,8 @@ DumpTcgEfiSpecIdEventStruct (
   avoid library dependencies within TCG2 code.
 
   @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+
+  @return size of a TCG_EfiSpecIDEventStruct instance.
 **/
 STATIC
 UINTN
@@ -969,7 +971,7 @@ Tpm2DebugLibGetTcgEfiSpecIdEventStructSize (
 }
 
 /**
-  This function returns size of TCG PCR event 2.
+  This function returns the size of a TCG PCR event 2 instance.
 
   @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
 
@@ -1020,14 +1022,14 @@ GetPcrEvent2Size (
 
   DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
 
-  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+  CopyMem (&EventSize, DigestBuffer, sizeof (EventSize));
   EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
 
   return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
 }
 
 /**
-  This function dump event log.
+  This function dumps the provided event log.
 
   @param[in]  EventLogFormat     The type of the event log for which the information is requested.
   @param[in]  EventLogLocation   A pointer to the memory address of the event log.

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.c
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.c
@@ -9,8 +9,10 @@ MU_CHANGE
 
 **/
 
+#include <Uefi.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseLib.h>
+#include <Library/Tpm2DebugLib.h>
 
 #include <IndustryStandard/Tpm20.h>
 

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.inf
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.inf
@@ -31,4 +31,5 @@
   SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
+  BaseMemoryLib
   DebugLib

--- a/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.inf
+++ b/SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.inf
@@ -20,17 +20,15 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = ALL
 #
-
 
 [Sources]
   Tpm2DebugLibVerbose.c
 
-
 [Packages]
   MdePkg/MdePkg.dec
-
+  SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
   DebugLib

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -729,7 +729,7 @@ Tcg2GetEventLog (
 {
   UINTN  Index;
 
-  DEBUG ((DEBUG_INFO, "Tcg2GetEventLog ... (0x%x)\n", EventLogFormat));
+  // DEBUG ((DEBUG_INFO, "Tcg2GetEventLog ... (0x%x)\n", EventLogFormat)); // MU_CHANGE: Remove print
 
   if (This == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -767,7 +767,7 @@ Tcg2GetEventLog (
 
   if (EventLogLocation != NULL) {
     *EventLogLocation = mTcgDxeData.EventLogAreaStruct[Index].Lasa;
-    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLocation - %x)\n", *EventLogLocation));
+    // DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLocation - %x)\n", *EventLogLocation)); // MU_CHANGE: Remove print
   }
 
   if (EventLogLastEntry != NULL) {
@@ -777,15 +777,15 @@ Tcg2GetEventLog (
       *EventLogLastEntry = (EFI_PHYSICAL_ADDRESS)(UINTN)mTcgDxeData.EventLogAreaStruct[Index].LastEvent;
     }
 
-    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLastEntry - %x)\n", *EventLogLastEntry));
+    // DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLastEntry - %x)\n", *EventLogLastEntry)); // MU_CHANGE: Remove print
   }
 
   if (EventLogTruncated != NULL) {
     *EventLogTruncated = mTcgDxeData.EventLogAreaStruct[Index].EventLogTruncated;
-    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogTruncated - %x)\n", *EventLogTruncated));
+    // DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogTruncated - %x)\n", *EventLogTruncated)); MU_CHANGE: Remove print
   }
 
-  DEBUG ((DEBUG_INFO, "Tcg2GetEventLog - %r\n", EFI_SUCCESS));
+  // DEBUG ((DEBUG_INFO, "Tcg2GetEventLog - %r\n", EFI_SUCCESS)); // MU_CHANGE: Remove print
 
   // Dump Event Log for debug purpose
   if ((EventLogLocation != NULL) && (EventLogLastEntry != NULL)) {
@@ -1144,12 +1144,12 @@ TcgDxeLogHashEvent (
   UINT8           *DigestBuffer;
   UINT32          *EventSizePtr;
 
-  DEBUG ((DEBUG_INFO, "SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
+  DEBUG ((DEBUG_VERBOSE, "SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs)); // MU_CHANGE: Downgrade debug message
 
   RetStatus = EFI_SUCCESS;
   for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
     if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
-      DEBUG ((DEBUG_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
+      DEBUG ((DEBUG_VERBOSE, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat)); // MU_CHANGE: Downgrade debug message
       switch (mTcg2EventInfo[Index].LogFormat) {
         case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
           Status = GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
@@ -1474,7 +1474,7 @@ Tcg2SubmitCommand (
 {
   EFI_STATUS  Status;
 
-  DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand ...\n"));
+  // DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand ...\n")); MU_CHANGE: Remove noisy print
 
   if ((This == NULL) ||
       (InputParameterBlockSize == 0) || (InputParameterBlock == NULL) ||
@@ -1501,7 +1501,7 @@ Tcg2SubmitCommand (
              &OutputParameterBlockSize,
              OutputParameterBlock
              );
-  DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand - %r\n", Status));
+  // DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand - %r\n", Status)); MU_CHANGE: Remove noisy print
   return Status;
 }
 

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -54,6 +54,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DeviceStateLib.h>
 #include <Library/PanicLib.h>
 // MU_CHANGE [END]
+#include <Library/Tpm2DebugLib.h> // MU_CHANGE - Use Tpm2DebugLib
 
 // #define PERF_ID_TCG2_DXE  0x3120 // MU_CHANGE
 
@@ -152,26 +153,28 @@ MeasurePeImageAndExtend (
   OUT TPML_DIGEST_VALUES    *DigestList
   );
 
-/**
+// MU_CHANGE BEGIN: Move to Tpm2DebugLib
+// /**
 
-  This function dump raw data.
+//   This function dump raw data.
 
-  @param  Data  raw data
-  @param  Size  raw data size
+//   @param  Data  raw data
+//   @param  Size  raw data size
 
-**/
-VOID
-InternalDumpData (
-  IN UINT8  *Data,
-  IN UINTN  Size
-  )
-{
-  UINTN  Index;
+// **/
+// VOID
+// InternalDumpData (
+//   IN UINT8  *Data,
+//   IN UINTN  Size
+//   )
+// {
+//   UINTN  Index;
 
-  for (Index = 0; Index < Size; Index++) {
-    DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
-  }
-}
+//   for (Index = 0; Index < Size; Index++) {
+//     DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
+//   }
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
 
@@ -249,40 +252,42 @@ InitNoActionEvent (
   WriteUnaligned32 ((UINT32 *)DigestBuffer, EventSize);
 }
 
-/**
+// MU_CHANGE BEGIN: Move to Tpm2DebugLib
+// /**
 
-  This function dump raw data with colume format.
+//   This function dump raw data with colume format.
 
-  @param  Data  raw data
-  @param  Size  raw data size
+//   @param  Data  raw data
+//   @param  Size  raw data size
 
-**/
-VOID
-InternalDumpHex (
-  IN UINT8  *Data,
-  IN UINTN  Size
-  )
-{
-  UINTN  Index;
-  UINTN  Count;
-  UINTN  Left;
+// **/
+// VOID
+// InternalDumpHex (
+//   IN UINT8  *Data,
+//   IN UINTN  Size
+//   )
+// {
+//   UINTN  Index;
+//   UINTN  Count;
+//   UINTN  Left;
 
-  #define COLUME_SIZE  (16 * 2)
+//   #define COLUME_SIZE  (16 * 2)
 
-  Count = Size / COLUME_SIZE;
-  Left  = Size % COLUME_SIZE;
-  for (Index = 0; Index < Count; Index++) {
-    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
-    InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
-    DEBUG ((DEBUG_INFO, "\n"));
-  }
+//   Count = Size / COLUME_SIZE;
+//   Left  = Size % COLUME_SIZE;
+//   for (Index = 0; Index < Count; Index++) {
+//     DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+//     InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
+//     DEBUG ((DEBUG_INFO, "\n"));
+//   }
 
-  if (Left != 0) {
-    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
-    InternalDumpData (Data + Index * COLUME_SIZE, Left);
-    DEBUG ((DEBUG_INFO, "\n"));
-  }
-}
+//   if (Left != 0) {
+//     DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+//     InternalDumpData (Data + Index * COLUME_SIZE, Left);
+//     DEBUG ((DEBUG_INFO, "\n"));
+//   }
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
   Get All processors EFI_CPU_LOCATION in system. LocationBuf is allocated inside the function
@@ -428,78 +433,80 @@ Tcg2GetCapability (
   return EFI_SUCCESS;
 }
 
-/**
-  This function dump PCR event.
+// MU_CHANGE BEGIN: Move to Tpm2DebugLib
+// /**
+//   This function dump PCR event.
 
-  @param[in]  EventHdr     TCG PCR event structure.
-**/
-VOID
-DumpEvent (
-  IN TCG_PCR_EVENT_HDR  *EventHdr
-  )
-{
-  UINTN  Index;
+//   @param[in]  EventHdr     TCG PCR event structure.
+// **/
+// VOID
+// DumpEvent (
+//   IN TCG_PCR_EVENT_HDR  *EventHdr
+//   )
+// {
+//   UINTN  Index;
 
-  DEBUG ((DEBUG_INFO, "  Event:\n"));
-  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
-  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
-  DEBUG ((DEBUG_INFO, "    Digest    - "));
-  for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
-    DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
-  }
+//   DEBUG ((DEBUG_INFO, "  Event:\n"));
+//   DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
+//   DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
+//   DEBUG ((DEBUG_INFO, "    Digest    - "));
+//   for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
+//     DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
+//   }
 
-  DEBUG ((DEBUG_INFO, "\n"));
-  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
-  InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
-}
+//   DEBUG ((DEBUG_INFO, "\n"));
+//   DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
+//   InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
+// }
 
-/**
-  This function dump TCG_EfiSpecIDEventStruct.
+// /**
+//   This function dump TCG_EfiSpecIDEventStruct.
 
-  @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
-**/
-VOID
-DumpTcgEfiSpecIdEventStruct (
-  IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
-  )
-{
-  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
-  UINTN                            Index;
-  UINT8                            *VendorInfoSize;
-  UINT8                            *VendorInfo;
-  UINT32                           NumberOfAlgorithms;
+//   @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+// **/
+// VOID
+// DumpTcgEfiSpecIdEventStruct (
+//   IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
+//   )
+// {
+//   TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+//   UINTN                            Index;
+//   UINT8                            *VendorInfoSize;
+//   UINT8                            *VendorInfo;
+//   UINT32                           NumberOfAlgorithms;
 
-  DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
-  DEBUG ((DEBUG_INFO, "    signature          - '"));
-  for (Index = 0; Index < sizeof (TcgEfiSpecIdEventStruct->signature); Index++) {
-    DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
-  }
+//   DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
+//   DEBUG ((DEBUG_INFO, "    signature          - '"));
+//   for (Index = 0; Index < sizeof (TcgEfiSpecIdEventStruct->signature); Index++) {
+//     DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
+//   }
 
-  DEBUG ((DEBUG_INFO, "'\n"));
-  DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
-  DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
-  DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
+//   DEBUG ((DEBUG_INFO, "'\n"));
+//   DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
+//   DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
+//   DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
 
-  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
-  DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
+//   CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+//   DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
 
-  DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
-  for (Index = 0; Index < NumberOfAlgorithms; Index++) {
-    DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
-    DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
-    DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
-  }
+//   DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+//   for (Index = 0; Index < NumberOfAlgorithms; Index++) {
+//     DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
+//     DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
+//     DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
+//   }
 
-  VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
-  DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
-  VendorInfo = VendorInfoSize + 1;
-  DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
-  for (Index = 0; Index < *VendorInfoSize; Index++) {
-    DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
-  }
+//   VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
+//   DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
+//   VendorInfo = VendorInfoSize + 1;
+//   DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
+//   for (Index = 0; Index < *VendorInfoSize; Index++) {
+//     DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
+//   }
 
-  DEBUG ((DEBUG_INFO, "\n"));
-}
+//   DEBUG ((DEBUG_INFO, "\n"));
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
   This function get size of TCG_EfiSpecIDEventStruct.
@@ -522,183 +529,185 @@ GetTcgEfiSpecIdEventStructSize (
   return sizeof (TCG_EfiSpecIDEventStruct) + sizeof (UINT32) + (NumberOfAlgorithms * sizeof (TCG_EfiSpecIdEventAlgorithmSize)) + sizeof (UINT8) + (*VendorInfoSize);
 }
 
-/**
-  This function dump PCR event 2.
+// MU_CHANGE [BEGIN] - Move to Tpm2DebugLib
+// /**
+//   This function dump PCR event 2.
 
-  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
-**/
-VOID
-DumpEvent2 (
-  IN TCG_PCR_EVENT2  *TcgPcrEvent2
-  )
-{
-  UINTN          Index;
-  UINT32         DigestIndex;
-  UINT32         DigestCount;
-  TPMI_ALG_HASH  HashAlgo;
-  UINT32         DigestSize;
-  UINT8          *DigestBuffer;
-  UINT32         EventSize;
-  UINT8          *EventBuffer;
+//   @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+// **/
+// VOID
+// DumpEvent2 (
+//   IN TCG_PCR_EVENT2  *TcgPcrEvent2
+//   )
+// {
+//   UINTN          Index;
+//   UINT32         DigestIndex;
+//   UINT32         DigestCount;
+//   TPMI_ALG_HASH  HashAlgo;
+//   UINT32         DigestSize;
+//   UINT8          *DigestBuffer;
+//   UINT32         EventSize;
+//   UINT8          *EventBuffer;
 
-  DEBUG ((DEBUG_INFO, "  Event:\n"));
-  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
-  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
+//   DEBUG ((DEBUG_INFO, "  Event:\n"));
+//   DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
+//   DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
 
-  DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
+//   DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
 
-  DigestCount  = TcgPcrEvent2->Digest.count;
-  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
-  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
-  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
-    DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
-    for (Index = 0; Index < DigestSize; Index++) {
-      DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
-    }
+//   DigestCount  = TcgPcrEvent2->Digest.count;
+//   HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+//   DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+//   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+//     DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
+//     DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
+//     DigestSize = GetHashSizeFromAlgo (HashAlgo);
+//     for (Index = 0; Index < DigestSize; Index++) {
+//       DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
+//     }
 
-    DEBUG ((DEBUG_INFO, "\n"));
-    //
-    // Prepare next
-    //
-    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
-    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
-  }
+//     DEBUG ((DEBUG_INFO, "\n"));
+//     //
+//     // Prepare next
+//     //
+//     CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+//     DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+//   }
 
-  DEBUG ((DEBUG_INFO, "\n"));
-  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+//   DEBUG ((DEBUG_INFO, "\n"));
+//   DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
 
-  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
-  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
-  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
-  InternalDumpHex (EventBuffer, EventSize);
-}
+//   CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+//   DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
+//   EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+//   InternalDumpHex (EventBuffer, EventSize);
+// }
 
-/**
-  This function returns size of TCG PCR event 2.
+// /**
+//   This function returns size of TCG PCR event 2.
 
-  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+//   @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
 
-  @return size of TCG PCR event 2.
-**/
-UINTN
-GetPcrEvent2Size (
-  IN TCG_PCR_EVENT2  *TcgPcrEvent2
-  )
-{
-  UINT32         DigestIndex;
-  UINT32         DigestCount;
-  TPMI_ALG_HASH  HashAlgo;
-  UINT32         DigestSize;
-  UINT8          *DigestBuffer;
-  UINT32         EventSize;
-  UINT8          *EventBuffer;
+//   @return size of TCG PCR event 2.
+// **/
+// UINTN
+// GetPcrEvent2Size (
+//   IN TCG_PCR_EVENT2  *TcgPcrEvent2
+//   )
+// {
+//   UINT32         DigestIndex;
+//   UINT32         DigestCount;
+//   TPMI_ALG_HASH  HashAlgo;
+//   UINT32         DigestSize;
+//   UINT8          *DigestBuffer;
+//   UINT32         EventSize;
+//   UINT8          *EventBuffer;
 
-  DigestCount  = TcgPcrEvent2->Digest.count;
-  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
-  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
-  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
-    //
-    // Prepare next
-    //
-    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
-    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
-  }
+//   DigestCount  = TcgPcrEvent2->Digest.count;
+//   HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+//   DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+//   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+//     DigestSize = GetHashSizeFromAlgo (HashAlgo);
+//     //
+//     // Prepare next
+//     //
+//     CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+//     DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+//   }
 
-  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+//   DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
 
-  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
-  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+//   CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+//   EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
 
-  return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
-}
+//   return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
+// }
 
-/**
-  This function dump event log.
+// /**
+//   This function dump event log.
 
-  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
-  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
-  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
-                                 address of the start of the last entry in the event log in memory.
-  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
-**/
-VOID
-DumpEventLog (
-  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
-  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
-  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
-  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
-  )
-{
-  TCG_PCR_EVENT_HDR         *EventHdr;
-  TCG_PCR_EVENT2            *TcgPcrEvent2;
-  TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
-  UINT64                    NumberOfEvents; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+//   @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+//   @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+//   @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+//                                  address of the start of the last entry in the event log in memory.
+//   @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+// **/
+// VOID
+// DumpEventLog (
+//   IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+//   IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+//   IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+//   IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+//   )
+// {
+//   TCG_PCR_EVENT_HDR         *EventHdr;
+//   TCG_PCR_EVENT2            *TcgPcrEvent2;
+//   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
+//   UINT64                    NumberOfEvents; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
 
-  DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
+//   DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
 
-  switch (EventLogFormat) {
-    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
-      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
-        // MU_CHANGE - CodeQL Change
-        DumpEvent (EventHdr);
-        EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
-      }
+//   switch (EventLogFormat) {
+//     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
+//       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+//       while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
+//         // MU_CHANGE - CodeQL Change
+//         DumpEvent (EventHdr);
+//         EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+//       }
 
-      if (FinalEventsTable == NULL) {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
-      } else {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
-        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
-        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+//       if (FinalEventsTable == NULL) {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+//       } else {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+//         DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+//         DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
 
-        EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
-        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
-          DumpEvent (EventHdr);
-          EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
-        }
-      }
+//         EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
+//         for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+//           DumpEvent (EventHdr);
+//           EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+//         }
+//       }
 
-      break;
-    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
-      //
-      // Dump first event
-      //
-      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      DumpEvent (EventHdr);
+//       break;
+//     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
+//       //
+//       // Dump first event
+//       //
+//       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+//       DumpEvent (EventHdr);
 
-      TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)(EventHdr + 1);
-      DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
+//       TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)(EventHdr + 1);
+//       DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
 
-      TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
-        // MU_CHANGE -  CodeQL
-        DumpEvent2 (TcgPcrEvent2);
-        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
-      }
+//       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
+//       while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+//         // MU_CHANGE -  CodeQL
+//         DumpEvent2 (TcgPcrEvent2);
+//         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+//       }
 
-      if (FinalEventsTable == NULL) {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
-      } else {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
-        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
-        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+//       if (FinalEventsTable == NULL) {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+//       } else {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+//         DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+//         DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
 
-        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
-        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
-          DumpEvent2 (TcgPcrEvent2);
-          TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
-        }
-      }
+//         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
+//         for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+//           DumpEvent2 (TcgPcrEvent2);
+//           TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+//         }
+//       }
 
-      break;
-  }
+//       break;
+//   }
 
-  return;
-}
+//   return;
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
   The EFI_TCG2_PROTOCOL Get Event Log function call allows a caller to

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -75,6 +75,7 @@
   DeviceStateLib
   PanicLib
   ## MU_CHANGE [END]
+  Tpm2DebugLib # MU_CHANGE - Add Tpm2DebugLib
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"


### PR DESCRIPTION
## Description

This PR consists of three commits:

SecurityPkg: Remove/Downgrade Noisy TCG Prints
--
The TCG code is very noisy when a TPM is connected. This commit downgrades some prints to verbose and removes some others that do not have value (such as function enter and exit prints).

SecurityPkg: Tpm2DebugLib: Clean Up Foundations
--
The Tpm2DebugLib varieties were missing some common things, such as including their own header, SecurityPkg.dec as a package, and including headers for data structures used in the source code.

SecurityPkg: Tpm2DebugLib: Move Noisy Debug Prints to Verbose Lib
--
The TCG code is very noisy, especially when printing PCR digests and the event log. E.g. in a platform printing at info level, ~4000 messages of the 5700 messages in the serial log were from the TCG code.

This patch moves the noisy prints to the verbose version of Tpm2DebugLib so that the log is not spammed, the code and strings can be dropped from the FW, but it is still available for debugging when needed.

Note, the definition of a noisy log is subjective, so please feel free to note the usefulness of a given log and it can be kept or modified.

Note pt 2: This entire library will be upstreamed to edk2 after these changes are merged.

Note pt 3: `DUMP_HEX` is also not upstreamed to edk2, so after this library is upstreamed with the direct copy, the custom hex dumping will be removed in favor of `DUMP_HEX` (along with other places in the code using custom hex dumping).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Build tested.

## Integration Instructions

Ensure Tpm2DebugLib is in the `[LibraryClasses]` section of the platform DSC. It is anticipated it already is due to its use in Tcg2Dxe, which is why this breaking change is backported to the release branch; it is not expected to break platforms currently using Mu.
