### PR TITLE
EmbeddedPkg: Add IoMmu support to CoherentDmaLib & NonCoherentDmaLib

### DIFF
--- a/EmbeddedPkg/EmbeddedPkg.dsc
+++ b/EmbeddedPkg/EmbeddedPkg.dsc
@@ -73,6 +73,7 @@
  # Need to change this for IPF
  #
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf                                         ## MU_CHANGE
 
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf

--- a/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.c
+++ b/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.c
@@ -11,6 +11,9 @@
 #include <Library/DebugLib.h>
 #include <Library/DmaLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/IoMmuLib.h> // MU_CHANGE
+
+#include <Protocol/IoMmu.h>   // MU_CHANGE
 
 STATIC
 PHYSICAL_ADDRESS
@@ -51,6 +54,14 @@ DmaMap (
   OUT    VOID               **Mapping
   )
 {
+  // MU_CHANGE [BEGIN]
+  EFI_STATUS             Status;
+  VOID                   *IoMmuHostAddress;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  // MU_CHANGE [END]
+
   if ((HostAddress == NULL) ||
       (NumberOfBytes == NULL) ||
       (DeviceAddress == NULL) ||
@@ -59,9 +70,72 @@ DmaMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  *DeviceAddress = HostToDeviceAddress (HostAddress);
-  *Mapping       = NULL;
+  *DeviceAddress   = HostToDeviceAddress (HostAddress);
+  IoMmuHostAddress = HostAddress; // MU_CHANGE
+  *Mapping         = NULL;
+
+  // MU_CHANGE [BEGIN]
+
+  switch (Operation) {
+    case MapOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case MapOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case MapOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE);
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             Mapping
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuSetAttribute (
+             NULL,
+             *Mapping,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    goto Unmap;
+  }
+
+  // MU_CHANGE [END]
   return EFI_SUCCESS;
+
+  // MU_CHANGE [BEGIN]
+Unmap:
+  Status = IoMmuUnmap (*Mapping);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+  }
+
+  // MU_CHANGE [END]
+
+  return Status;
 }
 
 /**
@@ -80,6 +154,24 @@ DmaUnmap (
   IN  VOID  *Mapping
   )
 {
+  // MU_CHANGE [BEGIN]
+  EFI_STATUS  Status;
+
+  Status = IoMmuSetAttribute (NULL, Mapping, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (Mapping);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  // MU_CHANGE [END]
   return EFI_SUCCESS;
 }
 

--- a/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.inf
+++ b/EmbeddedPkg/Library/CoherentDmaLib/CoherentDmaLib.inf
@@ -20,11 +20,13 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec     ## MU_CHANGE
   EmbeddedPkg/EmbeddedPkg.dec
 
 [LibraryClasses]
   DebugLib
   MemoryAllocationLib
+  IoMmuLib                          ## MU_CHANGE
 
 [Pcd]
   gEmbeddedTokenSpaceGuid.PcdDmaDeviceOffset

--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.c
@@ -18,7 +18,9 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/IoLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/IoMmuLib.h> // MU_CHANGE
 
+#include <Protocol/IoMmu.h>   // MU_CHANGE
 #include <Protocol/Cpu.h>
 
 typedef struct {
@@ -27,6 +29,7 @@ typedef struct {
   UINTN                   NumberOfBytes;
   DMA_MAP_OPERATION       Operation;
   BOOLEAN                 DoubleBuffer;
+  VOID                    *IoMmuContext; // MU_CHANGE
 } MAP_INFO_INSTANCE;
 
 typedef struct {
@@ -202,6 +205,13 @@ DmaMap (
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
   UINTN                            AllocSize;
 
+  // MU_CHANGE [BEGIN]
+  VOID                   *IoMmuHostAddress;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  // MU_CHANGE [END]
+
   if ((HostAddress == NULL) ||
       (NumberOfBytes == NULL) ||
       (DeviceAddress == NULL) ||
@@ -214,7 +224,8 @@ DmaMap (
     return EFI_INVALID_PARAMETER;
   }
 
-  *DeviceAddress = HostToDeviceAddress (HostAddress);
+  *DeviceAddress   = HostToDeviceAddress (HostAddress);
+  IoMmuHostAddress = HostAddress;  // MU_CHANGE
 
   // Remember range so we can flush on the other side
   Map = AllocatePool (sizeof (MAP_INFO_INSTANCE));
@@ -249,7 +260,8 @@ DmaMap (
             EfiCpuFlushTypeWriteBack
             );
 
-    *DeviceAddress = HostToDeviceAddress (Map->BufferAddress);
+    *DeviceAddress   = HostToDeviceAddress (Map->BufferAddress);
+    IoMmuHostAddress = Map->BufferAddress;  // MU_CHANGE
   } else if ((Operation != MapOperationBusMasterRead) &&
              ((((UINTN)HostAddress & (mCpu->DmaBufferAlignment - 1)) != 0) ||
               ((*NumberOfBytes & (mCpu->DmaBufferAlignment - 1)) != 0)))
@@ -286,8 +298,9 @@ DmaMap (
         goto FreeMapInfo;
       }
 
-      Buffer         = ALIGN_POINTER (Map->BufferAddress, mCpu->DmaBufferAlignment);
-      *DeviceAddress = HostToDeviceAddress (Buffer);
+      Buffer           = ALIGN_POINTER (Map->BufferAddress, mCpu->DmaBufferAlignment);
+      *DeviceAddress   = HostToDeviceAddress (Buffer);
+      IoMmuHostAddress = Buffer;  // MU_CHANGE
 
       //
       // Get rid of any dirty cachelines covering the double buffer. This
@@ -338,10 +351,71 @@ DmaMap (
   Map->HostAddress   = (UINTN)HostAddress;
   Map->NumberOfBytes = *NumberOfBytes;
   Map->Operation     = Operation;
+  Map->IoMmuContext  = NULL; // MU_CHANGE
 
   *Mapping = Map;
 
+  // MU_CHANGE [BEGIN]
+
+  switch (Operation) {
+    case MapOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case MapOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case MapOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE);
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &Map->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    goto FreeMapInfo;
+  }
+
+  Status = IoMmuSetAttribute (
+             NULL,
+             Map->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    goto Unmap;
+  }
+
+  // MU_CHANGE [END]
+
   return EFI_SUCCESS;
+
+  // MU_CHANGE [BEGIN]
+Unmap:
+  Status = IoMmuUnmap (Map->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+  }
+
+  // MU_CHANGE [END]
 
 CommonBufferError:
   DEBUG ((
@@ -389,6 +463,24 @@ DmaUnmap (
   }
 
   Map = (MAP_INFO_INSTANCE *)Mapping;
+
+  // MU_CHANGE [BEGIN]
+
+  Status = IoMmuSetAttribute (NULL, Map->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (Map->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  // MU_CHANGE [END]
 
   Status = EFI_SUCCESS;
   if (((UINTN)Map->HostAddress + Map->NumberOfBytes) > mDmaHostAddressLimit) {

--- a/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
+++ b/EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
@@ -24,6 +24,7 @@
 [Packages]
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec     ## MU_CHANGE
 
 [LibraryClasses]
   BaseMemoryLib
@@ -32,6 +33,7 @@
   IoLib
   MemoryAllocationLib
   UefiBootServicesTableLib
+  IoMmuLib                          ## MU_CHANGE
 
 [Protocols]
   gEfiCpuArchProtocolGuid


### PR DESCRIPTION
## Description

Add IoMmu support to CoherentDmaLib
Add IoMmu support to NonCoherentDmaLib
Uses IoMmuLib to do IoMmu protocol mappings.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on physical arm device

## Integration Instructions

Relies on https://github.com/microsoft/mu_basecore/pull/1364 to be merged first.