### PR TITLE
PrePiLib missing header that defines structures used in file

### DIFF
--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -11,6 +11,7 @@
 #define __PRE_PI_LIB_H__
 
 #include <Guid/ExtractSection.h>
+#include <Pi/PiPeiCis.h>
 
 /**
   This service enables discovery of additional firmware volumes.


### PR DESCRIPTION
## Description

Add the PiPeiCis header to add missing structure definitions used within PrePiLib.h

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Build using PrePiLib.h - file will explode without linker magic.

## Integration Instructions

N/A