### PR TITLE
[CHERRY-PICK] EmbeddedPkg: PrePiLib missing header used in file

### DIFF
--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -11,6 +11,7 @@
 #define __PRE_PI_LIB_H__
 
 #include <Guid/ExtractSection.h>
+#include <Pi/PiPeiCis.h>
 
 /**
   This service enables discovery of additional firmware volumes.


### PR DESCRIPTION
## Description

PrePiLib.h is missing the header file that defines the structures used in the file.

For example:
 - EFI_PEI_FV_HANDLE
 - EFI_PEI_FILE_HANDLE

(cherry picked from commit 15a2f3e511fbcaebc573f27a578ce75565de9894)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Use the header without linker magic and it'll explode.

## Integration Instructions

N/A 