### PR TITLE
[Rebase & FF] Fixing usage of `PcdTpmInstanceGuid` for ARM drivers

### DIFF
--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -447,13 +447,23 @@ InitializeTcgAcpiFfa (
   )
 {
   EFI_STATUS  Status;
+  // MU_CHANGE Starts: Check for FFA instance
+  VOID  *TpmGuid;
 
   DEBUG ((DEBUG_INFO, "TCG ACPI FFA Entry Point!\n"));
-
-  if (!CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm20DtpmGuid)) {
-    DEBUG ((DEBUG_ERROR, "No TPM2 DTPM instance required!\n"));
+  TpmGuid = PcdGetPtr (PcdTpmInstanceGuid);
+  if (TpmGuid == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a - Driver failed due to no TPM2 instance configured!\n", __func__));
     return EFI_UNSUPPORTED;
   }
+
+  if (!CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gTpm2ServiceFfaGuid)) {
+    // MU_CHANGE: Check for FFA instance
+    DEBUG ((DEBUG_ERROR, "%a - Driver failed due to no the system does not have a TPM2 FFA instance configured, not supported!!\n", __func__));
+    return EFI_UNSUPPORTED;
+  }
+
+  // MU_CHANGE Ends
 
   Status = PublishAcpiTable ();
   ASSERT_EFI_ERROR (Status);

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
@@ -48,7 +48,8 @@
   PcdLib
 
 [Guids]
-  gEfiTpmDeviceInstanceTpm20DtpmGuid                            ## PRODUCES ## GUID # TPM device identifier
+  # MU_CHANGE: Check for FFA instance
+  gTpm2ServiceFfaGuid                                           ## PRODUCES ## GUID # TPM device identifier
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                                     ## CONSUMES

--- a/SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.c
+++ b/SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.c
@@ -25,13 +25,15 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/Tcg2PhysicalPresenceLib.h>
 
 /**
-  This function checks if the required DTPM instance is TPM 2.0.
+  MU_CHANGE: Check for FFA instance as well.
+  This function checks if the required instance is a supported TPM 2.0 instance.
+  It currently supports two instances: dTPM and FFA.
 
-  @retval TRUE  The required DTPM instance is equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
-  @retval FALSE The required DTPM instance is not equal to gEfiTpmDeviceInstanceTpm20DtpmGuid.
+  @retval TRUE  The required DTPM instance is equal to gEfiTpmDeviceInstanceTpm20DtpmGuid or gTpm2ServiceFfaGuid.
+  @retval FALSE The required DTPM instance is not equal to either gEfiTpmDeviceInstanceTpm20DtpmGuid or gTpm2ServiceFfaGuid.
 **/
 BOOLEAN
-IsTpm20Dtpm (
+IsTpm20InstanceSupported (
   VOID
   )
 {
@@ -39,11 +41,15 @@ IsTpm20Dtpm (
 
   TpmGuid = PcdGetPtr (PcdTpmInstanceGuid);
   if (TpmGuid != NULL) {
-    if (CompareGuid ((EFI_GUID *)TpmGuid, &gEfiTpmDeviceInstanceTpm20DtpmGuid)) {
+    // MU_CHANGE Starts: Check for FFA instance as well.
+    if (CompareGuid ((EFI_GUID *)TpmGuid, &gEfiTpmDeviceInstanceTpm20DtpmGuid) ||
+        CompareGuid ((EFI_GUID *)TpmGuid, &gTpm2ServiceFfaGuid))
+    {
       return TRUE;
     }
 
-    DEBUG ((DEBUG_ERROR, "No TPM2 DTPM instance required! - %g\n", (EFI_GUID *)TpmGuid));
+    DEBUG ((DEBUG_ERROR, "Unsupported TPM2 instance configured - %g!\n", (EFI_GUID *)TpmGuid));
+    // MU_CHANGE Ends.
   } else {
     DEBUG ((DEBUG_ERROR, "NULL PcdTpmInstanceGuid set!\n"));
   }
@@ -150,8 +156,9 @@ InitializeTcgStandaloneMm (
   EFI_STATUS  Status;
   EFI_HANDLE  PpSwHandle;
 
-  if (!IsTpm20Dtpm ()) {
-    DEBUG ((DEBUG_ERROR, "No TPM2 DTPM instance required!\n"));
+  if (!IsTpm20InstanceSupported ()) {
+    // MU_CHANGE: Check for FFA instance as well.
+    DEBUG ((DEBUG_ERROR, "The system does not have a TPM2 DTPM/FFA instance configured, PPI not supported!\n"));
     Status = EFI_UNSUPPORTED;
     goto Cleanup;
   }

--- a/SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.inf
+++ b/SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.inf
@@ -54,7 +54,8 @@
   MemLib
 
 [Guids]
-  gEfiTpmDeviceInstanceTpm20DtpmGuid                            ## PRODUCES           ## GUID       # TPM device identifier
+  gEfiTpmDeviceInstanceTpm20DtpmGuid                            ## CONSUMES           ## GUID       # TPM device identifier
+  gTpm2ServiceFfaGuid                                           ## CONSUMES           ## GUID       # TPM device identifier # MU_CHANGE: Check for FFA instance
   gEdkiiTpmInstanceHobGuid
   gEfiPhysicalPresenceAcpiGuid
 


### PR DESCRIPTION
## Description

This update resolves PcdTpmInstanceGuid inconsistencies across two modules, streamlining its usage for all TPM-over-FFA modules.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on physical hardware platform.

## Integration Instructions

If not already, platform needs to set the following:
`gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{GUID("17b862a4-1806-4faf-86b3-089a58353861")}`