### PR TITLE
[Cherry-Pick] Update TPM over FFA library to support SEC phase usage

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.h
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.h
@@ -34,6 +34,9 @@
 #ifndef TPM2_DEVICE_LIB_FFA_H_
 #define TPM2_DEVICE_LIB_FFA_H_
 
+#define TPM2_FFA_INTERFACE_TYPE_UNKNOWN  0xFF
+#define TPM2_FFA_PARTITION_ID_INVALID    0x0000
+
 /**
   This function is used to get the TPM interface version.
 
@@ -188,6 +191,22 @@ FfaTpm2RequestUseTpm (
   );
 
 /**
+  This function is used to get the TPM service partition id via FF-A
+
+  @param[out] PartitionId - Supplies the pointer to the TPM service partition id.
+
+  @retval EFI_SUCCESS           The TPM command was successfully sent to the TPM
+                                and the response was copied to the Output buffer.
+  @retval EFI_INVALID_PARAMETER The TPM command buffer is NULL or the TPM command
+                                buffer size is 0.
+  @retval EFI_DEVICE_ERROR      An error occurred in communication with the TPM.
+**/
+EFI_STATUS
+FfaTpm2GetServicePartitionId (
+  OUT UINT16  *PartitionId
+  );
+
+/**
   Dump PTP register information.
 
   @param[in] Register                Pointer to PTP register.
@@ -208,6 +227,37 @@ EFI_STATUS
 EFIAPI
 InternalTpm2DeviceLibFfaConstructor (
   VOID
+  );
+
+/**
+ This function validate TPM interface type for TPM service over FF-A.
+
+ @retval EFI_SUCCESS           TPM interface type is valid.
+
+ @retval EFI_UNSUPPORTED       TPM interface type is invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+ValidateTpmInterfaceType (
+  VOID
+  );
+
+/**
+  This function is used to get the TPM service partition id.
+
+  @param[out] PartitionId - Supplies the pointer to the TPM service partition id.
+
+  @retval EFI_SUCCESS           The TPM command was successfully sent to the TPM
+                                and the response was copied to the Output buffer.
+  @retval EFI_INVALID_PARAMETER The TPM command buffer is NULL or the TPM command
+                                buffer size is 0.
+  @retval EFI_DEVICE_ERROR      An error occurred in communication with the TPM.
+**/
+EFI_STATUS
+EFIAPI
+GetTpmServicePartitionId (
+  OUT UINT16  *PartitionId
   );
 
 #endif /* _TPM2_DEVICE_LIB_SMC_H_ */

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
@@ -29,6 +29,7 @@
   Tpm2DeviceLibFfaBase.c
   Tpm2Ptp.c
   Tpm2DeviceLibFfa.h
+  Tpm2InfoFfa.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
@@ -1,0 +1,51 @@
+## @file
+#  Provides function interfaces to communicate with TPM 2.0 device
+#
+#  This library helps to use TPM 2.0 device in library function API
+#  based on FF-A using Command Response Buffer (CRB).
+#
+# Copyright (c), Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2DeviceSecLibFfa
+  FILE_GUID                      = d66e7482-615c-11f0-91d0-47f6d24396e9
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = Tpm2DeviceLib|SEC
+  CONSTRUCTOR                    = Tpm2DeviceLibFfaConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources.common]
+  Tpm2DeviceLibFfa.c
+  Tpm2ServiceFfaRaw.c
+  Tpm2DeviceLibFfaBase.c
+  Tpm2Ptp.c
+  Tpm2DeviceLibFfa.h
+  Tpm2InfoSecFfa.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  TimerLib
+  BaseMemoryLib
+  IoLib
+  ArmFfaLib
+
+[Guids]
+  gTpm2ServiceFfaGuid
+
+[Pcd.common]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress            ## CONSUMES

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InfoFfa.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InfoFfa.c
@@ -1,0 +1,87 @@
+/** @file
+  This library provides an interfaces to access DynamicPcds used
+  in Tpm2DeviceLibFfa.
+
+  Copyright (c) 2025, Arm Ltd. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Uefi/UefiBaseType.h>
+
+#include "Tpm2DeviceLibFfa.h"
+
+TPM2_PTP_INTERFACE_TYPE  mActiveTpmInterfaceType;
+
+/**
+ This function validate TPM interface type for TPM service over FF-A.
+
+ @retval EFI_SUCCESS           TPM interface type is valid.
+
+ @retval EFI_UNSUPPORTED       TPM interface type is invalid.
+
+**/
+EFI_STATUS
+ValidateTpmInterfaceType (
+  VOID
+  )
+{
+  mActiveTpmInterfaceType = PcdGet8 (PcdActiveTpmInterfaceType);
+
+  //
+  // Start by checking the PCD out of the gate and read from the CRB if it is invalid
+  //
+  if (mActiveTpmInterfaceType == TPM2_FFA_INTERFACE_TYPE_UNKNOWN) {
+    mActiveTpmInterfaceType = Tpm2GetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    PcdSet8S (PcdActiveTpmInterfaceType, mActiveTpmInterfaceType);
+  }
+
+  if (mActiveTpmInterfaceType != Tpm2PtpInterfaceCrb) {
+    return EFI_UNSUPPORTED;
+  }
+
+  DEBUG ((DEBUG_INFO, "Setting Tpm Active Interface Type %d\n", mActiveTpmInterfaceType));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function is used to get the TPM service partition id.
+
+  @param[out] PartitionId - Supplies the pointer to the TPM service partition id.
+
+  @retval EFI_SUCCESS           The TPM command was successfully sent to the TPM
+                                and the response was copied to the Output buffer.
+  @retval EFI_INVALID_PARAMETER The TPM command buffer is NULL or the TPM command
+                                buffer size is 0.
+  @retval EFI_DEVICE_ERROR      An error occurred in communication with the TPM.
+**/
+EFI_STATUS
+EFIAPI
+GetTpmServicePartitionId (
+  OUT UINT16  *PartitionId
+  )
+{
+  EFI_STATUS  Status;
+
+  if (PartitionId == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (PcdGet16 (PcdTpmServiceFfaPartitionId) != TPM2_FFA_PARTITION_ID_INVALID) {
+    *PartitionId = PcdGet16 (PcdTpmServiceFfaPartitionId);
+    return EFI_SUCCESS;
+  }
+
+  Status = FfaTpm2GetServicePartitionId (PartitionId);
+  if (!EFI_ERROR (Status)) {
+    PcdSet16S (PcdTpmServiceFfaPartitionId, *PartitionId);
+  }
+
+  return Status;
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InfoSecFfa.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InfoSecFfa.c
@@ -1,0 +1,62 @@
+/** @file
+  This library provides an interfaces to access DynamicPcds used
+  in Tpm2DeviceLibFfa.
+
+  Copyright (c) 2025, Arm Ltd. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Uefi/UefiBaseType.h>
+
+#include "Tpm2DeviceLibFfa.h"
+
+/**
+ This function validate TPM interface type for TPM service over FF-A.
+
+ @retval EFI_SUCCESS           TPM interface type is valid.
+
+ @retval EFI_UNSUPPORTED       TPM interface type is invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+ValidateTpmInterfaceType (
+  VOID
+  )
+{
+  TPM2_PTP_INTERFACE_TYPE  TpmInterfaceType;
+
+  TpmInterfaceType = Tpm2GetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+  if (TpmInterfaceType != Tpm2PtpInterfaceCrb) {
+    return EFI_UNSUPPORTED;
+  }
+
+  DEBUG ((DEBUG_INFO, "Setting Tpm Active Interface Type %d\n", TpmInterfaceType));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function is used to get the TPM service partition id.
+
+  @param[out] PartitionId - Supplies the pointer to the TPM service partition id.
+
+  @retval EFI_SUCCESS           The TPM command was successfully sent to the TPM
+                                and the response was copied to the Output buffer.
+  @retval EFI_INVALID_PARAMETER The TPM command buffer is NULL or the TPM command
+                                buffer size is 0.
+  @retval EFI_DEVICE_ERROR      An error occurred in communication with the TPM.
+**/
+EFI_STATUS
+EFIAPI
+GetTpmServicePartitionId (
+  OUT UINT16  *PartitionId
+  )
+{
+  return FfaTpm2GetServicePartitionId (PartitionId);
+}

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InstanceLibFfa.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InstanceLibFfa.inf
@@ -29,6 +29,7 @@
   Tpm2DeviceLibFfaBase.c
   Tpm2Ptp.c
   Tpm2DeviceLibFfa.h
+  Tpm2InfoFfa.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -408,6 +408,7 @@
   SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.inf
   SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.inf
   SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
+  SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
   SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2InstanceLibFfa.inf
 
 [BuildOptions]


### PR DESCRIPTION
## Description

This change adds the support for TPM over FFA usage in SEC phase.

Original EDK2 PR:
https://github.com/tianocore/edk2/pull/11297/commits

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This is tested on both virtual and hardware platforms and booted to OS desktop.

## Integration Instructions

For platforms need SEC phase TPM support:
`Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf`