### PR TITLE
[Rebase & FF] Add support for CRB Interface version 2

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -419,7 +419,10 @@ Tpm2GetPtpInterface (
   InterfaceCapability.Uint32 = MmioRead32 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->InterfaceCapability);
 
   if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_CRB) &&
-      (InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB) &&
+      // MU_CHANGE Starts: Add CRB v2 from Spec v1.06
+      ((InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB) ||
+       (InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB_V2)) &&
+      // MU_CHANGE Ends
       (InterfaceId.Bits.CapCRB != 0))
   {
     return Tpm2PtpInterfaceCrb;

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
@@ -75,7 +75,10 @@ Tpm2GetPtpInterface (
   InterfaceCapability.Uint32 = MmioRead32 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->InterfaceCapability);
 
   if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_CRB) &&
-      (InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB) &&
+      // MU_CHANGE Starts: Add CRB v2 from Spec v1.06
+      ((InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB) ||
+       (InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB_V2)) &&
+      // MU_CHANGE Ends
       (InterfaceId.Bits.CapCRB != 0))
   {
     return Tpm2PtpInterfaceCrb;


### PR DESCRIPTION
## Description

The CRB interface version 2 was added to TCG PC Client Platform TPM Profile (PTP) Specification v1.06:
https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-Version-1p06_pub.pdf

Table 21 — CRB Historical Interface Versions
<img width="1087" height="297" alt="image" src="https://github.com/user-attachments/assets/84447c8d-aaef-4fb1-9daf-8c1573d73a4a" />

This change adds the support at Tpm2DeviceLib level to recognize new CRB interface version.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This change was tested on proprietary hardware platform.

## Integration Instructions

N/A