### PR TITLE
SecurityPkg/Tpm2CommandLib: Update not found RC for Public NV Read

### DIFF
--- a/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
+++ b/SecurityPkg/Library/Tpm2CommandLib/Tpm2NVStorage.c
@@ -249,6 +249,7 @@ Tpm2NvReadPublic (
     case TPM_RC_SUCCESS:
       // return data
       break;
+    case TPM_RC_HANDLE:                            // MU_CHANGE: Treat 0x8B (TPM_RC_HANDLE) as EFI_NOT_FOUND.
     case TPM_RC_HANDLE + RC_NV_ReadPublic_nvIndex: // TPM_RC_NV_DEFINED:
       return EFI_NOT_FOUND;
     case TPM_RC_VALUE + RC_NV_ReadPublic_nvIndex:


### PR DESCRIPTION
## Description

Currently a EFI_DEVICE_ERROR is returned if `TPM_RC_HANDLE` is the return code from a TPM2_NV_ReadPublic command. However, in the TCG TPM Library Part 3: Commands specification, `TPM_RC_HANDLE` is a defined return code for the following:

  1. An Index does not exist that corresponds to the handle (TPM_RC_HANDLE)
  2. The hierarchy associated with the existing NV Index is not enabled (TPM_RC_HANDLE)

Therefore, return EFI_NOT_FOUND in this case, since that more precisely allows a caller to identify this condition and act on it as opposed to a more generic device error.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Verified `EFI_NOT_FOUND` is returned when the return code is `0x8B` in `Tpm2NvReadPublic()`.

## Integration Instructions

Review the new conditions for `EFI_NOT_FOUND` and adjust any status code handling if necessary.