### PR TITLE
[CHERRY-PICK] PrmPkg: Add ACPI Parameter Data Buffer Signature

### DIFF
--- a/PrmPkg/Include/PrmDataBuffer.h
+++ b/PrmPkg/Include/PrmDataBuffer.h
@@ -12,7 +12,8 @@
 
 #include <Uefi.h>
 
-#define PRM_DATA_BUFFER_HEADER_SIGNATURE  SIGNATURE_32('P','R','M','S')
+#define PRM_DATA_BUFFER_HEADER_SIGNATURE                 SIGNATURE_32('P','R','M','S')
+#define PRM_ACPI_PARAMETER_DATA_BUFFER_HEADER_SIGNATURE  SIGNATURE_32('P','R','M','P')
 
 #pragma pack(push, 1)
 


### PR DESCRIPTION
## Description

Cherry-Pick from upstream

In PRM spec 1.0 section 4.2.2 ACPI Parameter Buffer defines the signature of ACPI Parameter Data Buffer is 'PRMP'.

This commit adds the signature of ACPI Parameter Data Buffer.

(cherry picked from commit 980da7e0eb49bde53c877d172909388cbb72f9bd)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Build with Intel RC.

## Integration Instructions

N/A