### PR TITLE
FdtLib: fdt_rw.c - fix undefined pointer overflow behavior

### DIFF
--- a/EmbeddedPkg/Library/FdtLib/fdt_rw.c
+++ b/EmbeddedPkg/Library/FdtLib/fdt_rw.c
@@ -124,7 +124,7 @@ _fdt_splice (
   char  *p   = splicepoint;
   char  *end = (char *)fdt + _fdt_data_size (fdt);
 
-  if (((p + oldlen) < p) || ((p + oldlen) > end)) {
+  if ((unsigned int)oldlen > (end - p)) {
     return -FDT_ERR_BADOFFSET;
   }
 

--- a/EmbeddedPkg/Library/FdtLib/fdt_rw.c
+++ b/EmbeddedPkg/Library/FdtLib/fdt_rw.c
@@ -124,7 +124,7 @@ _fdt_splice (
   char  *p   = splicepoint;
   char  *end = (char *)fdt + _fdt_data_size (fdt);
 
-  if ((unsigned int)oldlen > (end - p)) {
+  if ((unsigned int)oldlen > (end - p)) {     // MU_CHANGE: Fix CodeQL warning - Pointer overflow check
     return -FDT_ERR_BADOFFSET;
   }
 


### PR DESCRIPTION
## Description

This change implements a fix for CodeQL issue: https://codeql.github.com/codeql-query-help/cpp/cpp-pointer-overflow-check/
It removes the potential for pointer overflow behavior.

This PR may be ignored as the edk2 stable tag for 202508 deletes the entire FdtLib anyways.
EDK2 PR that was rejected in favor of removing support of FdtLib. https://github.com/tianocore/edk2/pull/10955

- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

* I validated the CI build tests continue to pass. I also validated the change via QEMU emulation.

## Integration Instructions

* N/A