### PR TITLE
[CHERRY-PICK] FmpDevicePkg/FmpDxe: Improve handling of XDR certs

### DIFF
--- a/FmpDevicePkg/FmpDxe/FmpDxe.c
+++ b/FmpDevicePkg/FmpDxe/FmpDxe.c
@@ -923,8 +923,7 @@ CheckTheImageInternal (
         break;
       }
 
-      PublicKeyDataXdr += PublicKeyDataLength;
-      PublicKeyDataXdr  = (UINT8 *)ALIGN_POINTER (PublicKeyDataXdr, sizeof (UINT32));
+      PublicKeyDataXdr += ALIGN_VALUE (PublicKeyDataLength, 4);
     }
   }
 


### PR DESCRIPTION
## Description

The current implementation for XDR certificate handling assumes the PublicKeyDataXdr buffer is 4-byte aligned. This is not always the case. For example, if PublicKeyDataXdr=0x02, and the length is 0x05, the correct offset should be 0x2 + align_up(0x5, 4) -> 0x2 + 0x8 = 0xA. The current logic produces align_up(0x2 + 0x5, 4) -> align_up(0x7, 4) = 0x8.

(cherry picked from commit 17691a2641c2715fc1196aa1b0fe85b85db6c240)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- edk2 testing

## Integration Instructions

- N/A