### PR TITLE
[CHRRY-PICK][REBASE & FF] Use updated FFA run interface to extract FFA_DIRECT_RESP content

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
@@ -202,7 +202,7 @@ Tpm2GetInterfaceVersion (
   Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00);
+    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -254,7 +254,7 @@ Tpm2GetFeatureInfo (
   Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00);
+    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -298,7 +298,7 @@ Tpm2ServiceStart (
   Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00);
+    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -343,7 +343,7 @@ Tpm2RegisterNotification (
   Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00);
+    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -380,7 +380,7 @@ Tpm2UnregisterNotification (
   Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00);
+    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -417,7 +417,7 @@ Tpm2FinishNotified (
   Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00);
+    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
## Description

The original interface of FFA_RUN will consume the response if the secure partition requires FFA_RUN to resume the functionality. However, for a FFA_DIRECT_REQ2 command, which requires the response from the secure partition, the context loss will be detrimental to the system.

This change leverages the new interface and will consume the returned response from secure partitions.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on QEMU SBSA and booted to UEFI shell.

## Integration Instructions

Needs to update to the latest basecore.