### PR TITLE
[FF-A][TPM] Implement Tpm2StartupLib

### DIFF
--- a/SecurityPkg/Include/Library/Tpm2StartupLib.h
+++ b/SecurityPkg/Include/Library/Tpm2StartupLib.h
@@ -1,0 +1,26 @@
+/** @file
+  Definitions for TPM 2.0 startup and initialization
+
+Copyright (c), Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef TPM2_STARTUP_LIB_H_
+#define TPM2_STARTUP_LIB_H_
+
+/**
+  This function initializes the TPM if required
+
+  @retval EFI_SUCCESS       TPM successfully initialized
+  @retval EFI_UNSUPPORTED   TPM is not supported
+  @retval EFI_NOT_FOUND     TPM device not found
+  @retval EFI_DEVICE_ERROR  Unexpected device error
+**/
+EFI_STATUS
+EFIAPI
+Tpm2StartupInit (
+  VOID
+  );
+
+#endif

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
@@ -26,7 +26,7 @@
 [Sources.common]
   Tpm2DeviceLibFfa.c
   Tpm2ServiceFfaRaw.c
-  Tpm2DeviceLibFfaBase.c
+  Tpm2DeviceSecLibFfaBase.c ## MU_CHANGE
   Tpm2Ptp.c
   Tpm2DeviceLibFfa.h
   Tpm2InfoSecFfa.c

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfaBase.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfaBase.c
@@ -14,8 +14,6 @@
 #include <Library/Tpm2DeviceLib.h>
 #include "Tpm2DeviceLibFfa.h"
 
-UINT8  mCRBIdleByPass;
-
 /**
   Return cached PTP CRB interface IdleByPass state.
 
@@ -26,7 +24,7 @@ GetCachedIdleByPass (
   VOID
   )
 {
-  return mCRBIdleByPass;
+  return Tpm2GetIdleByPass ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
 }
 
 /**
@@ -42,20 +40,9 @@ InternalTpm2DeviceLibFfaConstructor (
   VOID
   )
 {
-  EFI_STATUS  Status;
-
-  mCRBIdleByPass = 0xFF;
-
   if (PcdGet64 (PcdTpmBaseAddress) == 0) {
     return EFI_NO_MAPPING;
   }
 
-  Status = ValidateTpmInterfaceType ();
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  mCRBIdleByPass = Tpm2GetIdleByPass ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
-
-  return EFI_SUCCESS;
+  return ValidateTpmInterfaceType ();
 }

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
@@ -26,18 +26,16 @@
 
 #include "Tpm2DeviceLibFfa.h"
 
-UINT16  mFfaTpm2PartitionId = TPM2_FFA_PARTITION_ID_INVALID;
-
 /**
   Check the return status from the FF-A call and returns EFI_STATUS
 
-  @param EFI_LOAD_ERROR  FF-A status code returned in x0
+  @param TpmReturnStatus  FF-A status code returned in x0
 
   @retval EFI_SUCCESS    The entry point is executed successfully.
 **/
 EFI_STATUS
 TranslateTpmReturnStatus (
-  UINTN  TpmReturnStatus
+  IN UINTN  TpmReturnStatus
   )
 {
   EFI_STATUS  Status;
@@ -142,27 +140,25 @@ Tpm2GetInterfaceVersion (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
   if (Version == NULL) {
-    Status = EFI_INVALID_PARAMETER;
-    goto Exit;
+    return EFI_INVALID_PARAMETER;
   }
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_GET_INTERFACE_VERSION;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
   Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
@@ -171,7 +167,6 @@ Tpm2GetInterfaceVersion (
     *Version = FfaDirectReq2Args.Arg1;
   }
 
-Exit:
   return Status;
 }
 
@@ -193,34 +188,29 @@ Tpm2GetFeatureInfo (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
   if (FeatureInfo == NULL) {
-    Status = EFI_INVALID_PARAMETER;
-    goto Exit;
+    return EFI_INVALID_PARAMETER;
   }
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_GET_FEATURE_INFO;
   FfaDirectReq2Args.Arg1 = TPM_SERVICE_FEATURE_SUPPORT_NOTIFICATION;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -241,30 +231,26 @@ Tpm2ServiceStart (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_START;
   FfaDirectReq2Args.Arg1 = (FuncQualifier & 0xFF);
   FfaDirectReq2Args.Arg2 = (LocalityQualifier & 0xFF);
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -286,30 +272,26 @@ Tpm2RegisterNotification (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_REGISTER_FOR_NOTIFICATION;
   FfaDirectReq2Args.Arg1 = (NotificationTypeQualifier << 16 | vCpuId);
   FfaDirectReq2Args.Arg2 = (NotificationId & 0xFF);
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -325,28 +307,24 @@ Tpm2UnregisterNotification (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_UNREGISTER_FROM_NOTIFICATION;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -362,26 +340,22 @@ Tpm2FinishNotified (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_FINISH_NOTIFIED;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (mFfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }

--- a/SecurityPkg/Library/Tpm2StartupLib/Tpm2StartupLib.c
+++ b/SecurityPkg/Library/Tpm2StartupLib/Tpm2StartupLib.c
@@ -1,0 +1,78 @@
+/** @file
+  Setup and initialization of TPM 2.0
+
+Copyright (c), Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Pi/PiMultiPhase.h>
+#include <Guid/TcgEventHob.h>
+#include <Guid/TpmInstance.h>
+
+#include <Library/Tpm2StartupLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+#include <Library/HobLib.h>
+#include <Library/ReportStatusCodeLib.h>
+
+/**
+  This function initializes the TPM if required
+
+  @retval EFI_SUCCESS       TPM successfully initialized
+  @retval EFI_UNSUPPORTED   TPM is not supported
+  @retval EFI_NOT_FOUND     TPM device not found
+  @retval EFI_DEVICE_ERROR  Unexpected device error
+**/
+EFI_STATUS
+EFIAPI
+Tpm2StartupInit (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "%a - Entry\n", __func__));
+
+  if (CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceNoneGuid) ||
+      CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm12Guid))
+  {
+    DEBUG ((DEBUG_INFO, "No TPM2 instance required!\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  // Request use of the TPM
+  Status = Tpm2RequestUseTpm ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "TPM2 not detected! Status: %r\n", Status));
+    goto Done;
+  }
+
+  // Determine if initialization is requested
+  if (PcdGet8 (PcdTpm2InitializationPolicy) == 1) {
+    // Setup/Initialize the TPM
+    Status = Tpm2Startup (TPM_SU_CLEAR);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm2Startup::%a - TPM failed Startup! Status: %r\n", __func__, Status));
+    }
+  }
+
+Done:
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "TPM2 error! Building Hob.\n"));
+    BuildGuidHob (&gTpmErrorHobGuid, 0);
+    REPORT_STATUS_CODE (
+      EFI_ERROR_CODE | EFI_ERROR_MINOR,
+      (PcdGet32 (PcdStatusCodeSubClassTpmDevice) | EFI_P_EC_INTERFACE_ERROR)
+      );
+  }
+
+  DEBUG ((DEBUG_INFO, "%a - Exit\n", __func__));
+
+  return Status;
+}

--- a/SecurityPkg/Library/Tpm2StartupLib/Tpm2StartupLib.inf
+++ b/SecurityPkg/Library/Tpm2StartupLib/Tpm2StartupLib.inf
@@ -1,0 +1,52 @@
+## @file
+#  Handles TPM 2.0 Startup/Initialization.
+#
+#  Includes setup of initial TPM state as well as any pre-DXE
+#  measurements. Also handles any pre-DXE logging by generating
+#  HOBs.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2StartupLib
+  FILE_GUID                      = 2066F14F-6CBB-44D2-A619-4100AADDD2E4
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = Tpm2StartupLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  Tpm2StartupLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  ReportStatusCodeLib
+  Tpm2CommandLib
+  Tpm2DeviceLib
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid              ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2InitializationPolicy     ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeSubClassTpmDevice  ## SOMETIMES_CONSUMES
+
+[Guids]
+  gTpmErrorHobGuid                ## SOMETIMES_PRODUCES     ## HOB
+  gEfiTpmDeviceInstanceNoneGuid   ## SOMETIMES_PRODUCES     ## GUID       # TPM device identifier
+  gEfiTpmDeviceInstanceTpm12Guid  ## SOMETIMES_PRODUCES     ## GUID       # TPM device identifier

--- a/SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.c
+++ b/SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.c
@@ -1,0 +1,24 @@
+/** @file
+  NULL instance of TPM 2.0 Startup
+
+Copyright (c), Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Library/Tpm2StartupLib.h>
+
+/**
+  This function initializes the TPM if required
+
+  @retval EFI_UNSUPPORTED   TPM is not supported
+**/
+EFI_STATUS
+EFIAPI
+Tpm2StartupInit (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf
+++ b/SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf
@@ -1,0 +1,32 @@
+## @file
+#  NULL Instance of Tpm2StartupLib
+#
+# Copyright (c), Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2StartupLibNull
+  FILE_GUID                      = 50C0A7B9-2059-41EA-AA0A-464220D1A232
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = Tpm2StartupLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  Tpm2StartupLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -51,6 +51,11 @@
   #
   Tpm2HelpLib|Include/Library/Tpm2HelpLib.h
 
+  ## MU_CHANGE
+  ##  @libraryclass This library provides TPM initialization and setup functionality.
+  ##
+  Tpm2StartupLib|Include/Library/Tpm2StartupLib.h
+
   ##  @libraryclass  Provides interfaces on how to access TPM 2.0 hardware device.
   #
   Tpm2DeviceLib|Include/Library/Tpm2DeviceLib.h

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -56,6 +56,7 @@
   Tpm12CommandLib|SecurityPkg/Library/Tpm12CommandLib/Tpm12CommandLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf             ## MU_CHANGE
+  Tpm2StartupLib|SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf  ## MU_CHANGE
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
   TcgPpVendorLib|SecurityPkg/Library/TcgPpVendorLibNull/TcgPpVendorLibNull.inf
   Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
@@ -219,6 +220,8 @@
 
   SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf   ## MU_CHANGE
+  SecurityPkg/Library/Tpm2StartupLib/Tpm2StartupLib.inf  ## MU_CHANGE
+  SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf  ## MU_CHANGE
   SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
   SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
   SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf


### PR DESCRIPTION
## Description

Implemented the Tpm2StartupLib which is meant to handle TPM initialization as well as any pre-DXE measurements. Updated the TPM libraries to include SEC versions which do not have global variables. This was causing issues with boot on our PEI-less QEMU SBSA platform when attempting to init the TPM in the SEC phase. A NULL version is also added for platforms who do not need any TPM initialization. The default is the NULL instance.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built and ran with TPM enabled on our QEMU SBSA build. Confirmed TPM communication and boot to UEFI shell.

## Integration Instructions

If needed, link in the non-NULL instance of the library into your .dsc and call the init function in the proper phase before DXE is loaded.