### PR TITLE
SecurityPkg: AuthVariableLib: Handle 0 entry signature list

### DIFF
--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -596,7 +596,7 @@ CheckSignatureListFormat (
 
       CertData = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) + SigList->SignatureHeaderSize);
       CertLen  = SigList->SignatureSize - sizeof (EFI_GUID);
-      if (!RsaGetPublicKeyFromX509 (CertData->SignatureData, CertLen, &RsaContext)) {
+      if ((CertLen > 0) && !RsaGetPublicKeyFromX509 (CertData->SignatureData, CertLen, &RsaContext)) {
         RsaFree (RsaContext);
         return EFI_INVALID_PARAMETER;
       }


### PR DESCRIPTION
## Description

Current implementation will fail to set authenticated variables if the signature list is empty. This could potentially happen when there is nothing revoked after certificate rotation.

This fix is added to handle this use case.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on a physical platform with empty signature list.

## Integration Instructions

N/A